### PR TITLE
function bloginfo() no returns.

### DIFF
--- a/functions_helpers.php
+++ b/functions_helpers.php
@@ -17,7 +17,7 @@ function lightning_print_headlogo() {
 	if (isset($options['head_logo']) && $options['head_logo']){
 		print '<img src="'.$options['head_logo'].'" alt="'.get_bloginfo('name').'" />';
 	} else {
-		echo bloginfo('name');
+		bloginfo('name');
 	}
 }
 


### PR DESCRIPTION
https://wpdocs.osdn.jp/%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88%E3%82%BF%E3%82%B0/bloginfo
bloginfo()は常に単体で出力する関数です。echo文で出力する必要はありません。
get_bloginfo() を使うべきか、echo文を除去するか、あえて残すかは御判断ください。