### PR TITLE
G3 スライドの静止時間が指定できないので、出来るようにする

### DIFF
--- a/_g3/inc/ltg-g3-slider/package/class-ltg-g3-slider.php
+++ b/_g3/inc/ltg-g3-slider/package/class-ltg-g3-slider.php
@@ -176,6 +176,32 @@ if ( ! class_exists( 'LTG_G3_Slider' ) ) {
 				)
 			);
 
+			// Stop time.
+			$wp_customize->add_setting(
+				'lightning_theme_options[top_slide_time]',
+				array(
+					'default'           => 4000,
+					'type'              => 'option',
+					'capability'        => 'edit_theme_options',
+					'sanitize_callback' => array( 'VK_Helpers', 'sanitize_number' ),
+				)
+			);
+
+			$wp_customize->add_control(
+				new VK_Custom_Text_Control(
+					$wp_customize,
+					'lightning_theme_options[top_slide_time]',
+					array(
+						'label'       => __( 'Slide rest time', 'lightning' ),
+						'section'     => 'ltg_g3_slider',
+						'settings'    => 'lightning_theme_options[top_slide_time]',
+						'type'        => 'text',
+						'description' => '',
+						'input_after' => __( 'millisecond', 'lightning' ),
+					)
+				)
+			);
+
 			// Slide interval time.
 			$wp_customize->add_setting(
 				'lightning_theme_options[top_slide_effect]',


### PR DESCRIPTION
- Slide transition time と同様にStop time.のテキストフィールドを追加
- オプションデータは669行目辺りで設定が書いてあったため不要でした

とりあえず翻訳はしなくて英語のままでOKとのことなので翻訳は出来ていません