### PR TITLE
Video Unit 用にスライド表示・非表示のフックを追加

### DIFF
--- a/_g3/index.php
+++ b/_g3/index.php
@@ -9,7 +9,9 @@ do_action( 'lightning_site_header_after' );
 ?>
 
 <?php if ( is_front_page() ) {
-    LTG_G3_Slider::display_html();
+	if ( apply_filters( 'lightning_default_slide_display', true ) ) { 
+    	LTG_G3_Slider::display_html(); 
+	}
 } ?>
 
 <?php if ( ! is_front_page() ) : ?>


### PR DESCRIPTION
・Video Unit 用にスライド表示・非表示のフック ( lightning_default_slide_display ) を追加しました。
関連：https://github.com/vektor-inc/lightning/issues/595