### PR TITLE
編集画面でキーカラーが反映されるように・・・

### DIFF
--- a/_g2/inc/customize/customize-design.php
+++ b/_g2/inc/customize/customize-design.php
@@ -548,13 +548,13 @@ function lightning_add_common_dynamic_css() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-design-style', $dynamic_css );
 }
-add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css' );
+add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css', 11 );
 
 function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
 }
-add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor' );
+add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );
 
 /*
   編集ショートカットボタンの位置調整（ウィジェットのショートカットボタンと重なってしまうため）

--- a/_g3/inc/customize/customize-design.php
+++ b/_g3/inc/customize/customize-design.php
@@ -137,4 +137,4 @@ function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
 }
-add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor' );
+add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );


### PR DESCRIPTION
編集画面でもキーカラー等の CSS を出力するようになりましたが、それより強い CSS で妨害されています。
多分 add_editor_style で読み込まれたものの可能性があります。