### PR TITLE
編集画面でキーカラーが反映されないのを修正

### DIFF
--- a/_g2/functions.php
+++ b/_g2/functions.php
@@ -191,13 +191,14 @@ function lightning_theme_style() {
 /*
   Load Editor CSS
 /*-------------------------------------------*/
-add_action( 'after_setup_theme', 'lightning_load_common_editor_css' );
+add_action( 'admin_enqueue_scripts', 'lightning_load_common_editor_css' );
 function lightning_load_common_editor_css() {
 	/*
 	 Notice : Use url then if you use local environment https has error that bring to get css error and don't refrected */
 	/* Notice : add_editor_style() is only one args. */
 	/* add_editor_style is for Classic Editor Only. */
-	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
+	global $post;
+	if ( ! function_exists( 'use_block_editor_for_post' ) || ! use_block_editor_for_post( $post ) ) {
 		add_editor_style( 'assets/css/common_editor.css' );
 	}
 }

--- a/_g2/functions.php
+++ b/_g2/functions.php
@@ -196,7 +196,10 @@ function lightning_load_common_editor_css() {
 	/*
 	 Notice : Use url then if you use local environment https has error that bring to get css error and don't refrected */
 	/* Notice : add_editor_style() is only one args. */
-	add_editor_style( 'assets/css/common_editor.css' );
+	/* add_editor_style is for Classic Editor Only. */
+	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
+		add_editor_style( 'assets/css/common_editor.css' );
+	}
 }
 
 /*

--- a/_g2/inc/customize/customize-design.php
+++ b/_g2/inc/customize/customize-design.php
@@ -548,7 +548,7 @@ function lightning_add_common_dynamic_css() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-design-style', $dynamic_css );
 }
-add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css' );
+add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css', 11 );
 
 function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();

--- a/_g2/inc/customize/customize-design.php
+++ b/_g2/inc/customize/customize-design.php
@@ -552,9 +552,9 @@ add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css' );
 
 function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
-	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css, 11 );
+	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
 }
-add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor' );
+add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );
 
 /*
   編集ショートカットボタンの位置調整（ウィジェットのショートカットボタンと重なってしまうため）

--- a/_g2/inc/customize/customize-design.php
+++ b/_g2/inc/customize/customize-design.php
@@ -552,7 +552,7 @@ add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css' );
 
 function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
-	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
+	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css, 11 );
 }
 add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor' );
 

--- a/_g2/inc/vk-css-optimize/package/class-css-tree-shaking.php
+++ b/_g2/inc/vk-css-optimize/package/class-css-tree-shaking.php
@@ -11,9 +11,9 @@ If you want to change this file, please change the original file.
  *
  * Version: 1.0.2
  * Author: enomoto@celtislab
+ * Modefied: Vektor:Inc.
  * Author URI: https://celtislab.net/
  * License: GPLv2
- *
  */
 namespace celtislab;
 
@@ -21,149 +21,174 @@ defined( 'ABSPATH' ) || exit;
 
 class CSS_tree_shaking {
 
-    private static $cmplist;
-    private static $varlist;
-    private static $jsaddlist;
-    private static $atrule_data;
+	private static $cmplist;
+	private static $varlist;
+	private static $jsaddlist;
+	private static $atrule_data;
 	function __construct() {}
 
-    // アットルール一時退避( @{md5key} に置き換えておく)
-    private static function atrule_store($css){
-        $pattern = array( '|(@(\-[\w]+\-)?keyframes.+?\{)(.+?\})\}|',
-                          '|(@(\-[\w]+\-)?supports.+?\{)(.+?\})\}|',
-                          '|(@(\-[\w]+\-)?media.+?\{)(.+?\})\}|',
-                          '|@[^;\{]+?;|',
-                          '|@[^;\{]+?\{(.+?)\}|'
-                        );
-        foreach ( $pattern as $atrule ) {
-            $css = preg_replace_callback( $atrule, function($matches) {
-                $key = 'AR_' . md5($matches[0]);
-                $data = $matches[0];
-                if(!empty($matches[3])){
-                    $incss = self::atrule_store( $matches[3] );
-                    $incss = self::tree_shaking( $incss );
-                    $data = (!empty($incss))? $matches[1] . $incss . '}' : '';
-                }
-               	self::$atrule_data[ $key ] = $data;
-                return '@{' . $key . '}';
-            }, $css);
-        }
-        return $css;
-    }
+	// アットルール一時退避( @{md5key} に置き換えておく)
+	private static function atrule_store( $css ) {
+		$pattern = array(
+			'|(@(\-[\w]+\-)?keyframes.+?\{)(.+?\})\}|',
+			'|(@(\-[\w]+\-)?supports.+?\{)(.+?\})\}|',
+			'|(@(\-[\w]+\-)?media.+?\{)(.+?\})\}|',
+			'|@[^;\{]+?;|',
+			'|@[^;\{]+?\{(.+?)\}|',
+		);
+		foreach ( $pattern as $atrule ) {
+			$css = preg_replace_callback(
+				$atrule,
+				function( $matches ) {
+					$key  = 'AR_' . md5( $matches[0] );
+					$data = $matches[0];
+					if ( ! empty( $matches[3] ) ) {
+						$incss = self::atrule_store( $matches[3] );
+						$incss = self::tree_shaking( $incss );
+						$data  = ( ! empty( $incss ) ) ? $matches[1] . $incss . '}' : '';
+					}
+					self::$atrule_data[ $key ] = $data;
+					return '@{' . $key . '}';
+				},
+				$css
+			);
+		}
+		return $css;
+	}
 
-    //アットルール復元
-    private static function atrule_restore($css){
-        $css = preg_replace_callback('|@\{(.+?)\}|', function($matches) {
-            $data = $matches[0];
-            $key = $matches[1];
-            if(strpos($key, 'AR_') !== false){
-                $data = (!empty(self::$atrule_data[ $key ]))? self::atrule_restore( self::$atrule_data[ $key ] ) : '';
-            }
-            return $data;
-        }, $css);
-        return $css;
-    }
+	// アットルール復元
+	private static function atrule_restore( $css ) {
+		$css = preg_replace_callback(
+			'|@\{(.+?)\}|',
+			function( $matches ) {
+				$data = $matches[0];
+				$key  = $matches[1];
+				if ( strpos( $key, 'AR_' ) !== false ) {
+					$data = ( ! empty( self::$atrule_data[ $key ] ) ) ? self::atrule_restore( self::$atrule_data[ $key ] ) : '';
+				}
+				return $data;
+			},
+			$css
+		);
+		return $css;
+	}
 
-    //CSS から未使用の id, class, tag を含む定義を削除
-    private static function tree_shaking($css) {
-        $ncss = preg_replace_callback("|(.+?)(\{.+?\})|u", function($matches) {
-            $data = $matches[0];
-            $sel = $matches[1];
-            if($sel !== '@'){
-                $pattern = array( 'id'    => '|(#)([\w\-\\%]+)|u',
-                                  'class' => '|(\.)([\w\-\\%]+)|u',
-                                  'tag'   => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu'
-                                );
+	// CSS から未使用の id, class, tag を含む定義を削除
+	private static function tree_shaking( $css ) {
+		$ncss = preg_replace_callback(
+			'|(.+?)(\{.+?\})|u',
+			function( $matches ) {
+				$data = $matches[0];
+				$sel  = $matches[1];
+				if ( $sel !== '@' ) {
+					$pattern = array(
+						'id'    => '|(#)([\w\-\\%]+)|u',
+						'class' => '|(\.)([\w\-\\%]+)|u',
+						'tag'   => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu',
+					);
 
-                $slist = array_map("trim", explode(',', $sel));
-                foreach ($slist as $s) {
-                    //selector の判定条件から :not(...) を除外 ($_s で判定して削除時は $s で行う)
-                    $_s = $s;
-                    if(preg_match('/:not\(.+?\)/', $s)){
-                        $_s = preg_replace( '/:not\(.+?\)/', '', $s );
-                    }
-                    foreach (array('id','class','tag') as $item) {
-                        if(!empty($_s) && preg_match_all( $pattern[$item], $_s, $match)){
-                            foreach ($match[2] as $val) {
-                                //$jsaddlist 登録名が一部でも含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
-                                if(in_array($val, self::$jsaddlist))
-                                    break;
+					$slist = array_map( 'trim', explode( ',', $sel ) );
+					foreach ( $slist as $s ) {
+						// selector の判定条件から :not(...) を除外 ($_s で判定して削除時は $s で行う)
+						$_s = $s;
+						if ( preg_match( '/:not\(.+?\)/', $s ) ) {
+							$_s = preg_replace( '/:not\(.+?\)/', '', $s );
+						}
+						foreach ( array( 'id', 'class', 'tag' ) as $item ) {
+							if ( ! empty( $_s ) && preg_match_all( $pattern[ $item ], $_s, $match ) ) {
+								foreach ( $match[2] as $val ) {
+									// $jsaddlist 登録名が一部でも含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
+									if ( in_array( $val, self::$jsaddlist ) ) {
+										break;
+									}
 
-                                //$cmplist 登録名に含まれていないものが一つでもあれば削除
-                                if(!preg_match('/^[0-9]+/', $val) && !in_array($val, self::$cmplist[$item])){
-                                    $sel = preg_replace( '/(' . preg_quote($s) . ')(,|$)/u', '$2', $sel, 1 );
-                                    $s = '';
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                $sel = preg_replace('/,+/su', ',', $sel);
-                $sel = preg_replace('/\s+/su', ' ', $sel);
-                $sel = trim($sel);
-                $sel = trim($sel, ',');
-                $data = (!empty($sel))? $sel . $matches[2] : '';
-            }
-            return $data;
-        }, $css);
-        return $ncss;
-    }
+									// $cmplist 登録名に含まれていないものが一つでもあれば削除
+									if ( ! preg_match( '/^[0-9]+/', $val ) && ! in_array( $val, self::$cmplist[ $item ] ) ) {
+										$sel = preg_replace( '/(' . preg_quote( $s ) . ')(,|$)/u', '$2', $sel, 1 );
+										$s   = '';
+										break;
+									}
+								}
+							}
+						}
+					}
+					$sel  = preg_replace( '/,+/su', ',', $sel );
+					$sel  = preg_replace( '/\s+/su', ' ', $sel );
+					$sel  = trim( $sel );
+					$sel  = trim( $sel, ',' );
+					$data = ( ! empty( $sel ) ) ? $sel . $matches[2] : '';
+				}
+				return $data;
+			},
+			$css
+		);
+		return $ncss;
+	}
 
-    //未使用変数定義の削除（tree_shaking 実行後に実施する必要あり）
-    public static function tree_shaking4var($css) {
-        $ncss = $css;
-        self::$varlist = array();
-        if(preg_match_all( '/var\((\-\-.+?)\)/iu', $css, $vmatchs)){
-            foreach ($vmatchs[1] as $v) {
-                $v = trim($v);
-                if(!in_array($v, self::$varlist)){
-                    self::$varlist[] = $v;
-                }
-            }
-        }
-        //url() 定義時は文字列中に ; がそのまま含まれている場合があるの分けて処理
-        $ncss = preg_replace_callback( '|(\-\-[\w\-]+?):url\(.+?\);?|u', function($matches) {
-            $data = $matches[0];
-            if(!in_array(trim($matches[1]), self::$varlist)){
-                $data = '';
-            }
-            return $data;
-        }, $ncss);
-        $ncss = preg_replace_callback( '|(\-\-[\w\-]+?):(.+?)([;\}])|u', function($matches) {
-            $data = $matches[0];
-            if(!preg_match('|url\(|u', $matches[2]) && !in_array(trim($matches[1]), self::$varlist)){
-                $data = ($matches[3] === '}')? '}' : '';
-            }
-            return $data;
-        }, $ncss);
+	// 未使用変数定義の削除（tree_shaking 実行後に実施する必要あり）
+	public static function tree_shaking4var( $css ) {
+		$ncss          = $css;
+		self::$varlist = array();
+		if ( preg_match_all( '/var\((\-\-.+?)\)/iu', $css, $vmatchs ) ) {
+			foreach ( $vmatchs[1] as $v ) {
+				$v = trim( $v );
+				if ( ! in_array( $v, self::$varlist ) ) {
+					self::$varlist[] = $v;
+				}
+			}
+		}
+		// url() 定義時は文字列中に ; がそのまま含まれている場合があるの分けて処理
+		$ncss = preg_replace_callback(
+			'|(\-\-[\w\-]+?):url\(.+?\);?|u',
+			function( $matches ) {
+				$data = $matches[0];
+				if ( ! in_array( trim( $matches[1] ), self::$varlist ) ) {
+					$data = '';
+				}
+				return $data;
+			},
+			$ncss
+		);
+		$ncss = preg_replace_callback(
+			'|(\-\-[\w\-]+?):(.+?)([;\}])|u',
+			function( $matches ) {
+				$data = $matches[0];
+				if ( ! preg_match( '|url\(|u', $matches[2] ) && ! in_array( trim( $matches[1] ), self::$varlist ) ) {
+					$data = ( $matches[3] === '}' ) ? '}' : '';
+				}
+				return $data;
+			},
+			$ncss
+		);
 
-        return $ncss;
-    }
+		return $ncss;
+	}
 
-    /*=============================================================
-     * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
-     */
-    public static function simple_minify( $css ) {
-        $res = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
-        if(!empty($res)){
-            $css = $res;
-            $css = str_replace(array("\r", "\n"), '', $css);
-            $css = str_replace("\t", ' ', $css);
-            $css = preg_replace('/\s+/su', ' ', $css);
-            $css = preg_replace('/\s([\{\}:=,\)*\/;>])/', '$1', $css);
-            $css = preg_replace('/([\{\}:=,\(*\/!;>])\s/', '$1', $css);
-        }
-        return $css;
-    }
+	/*
+	=============================================================
+	 * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
+	 */
+	public static function simple_minify( $css ) {
+		$res = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
+		if ( ! empty( $res ) ) {
+			$css = $res;
+			$css = str_replace( array( "\r", "\n" ), '', $css );
+			$css = str_replace( "\t", ' ', $css );
+			$css = preg_replace( '/\s+/su', ' ', $css );
+			$css = preg_replace( '/\s([\{\}:=,\)*\/;>])/', '$1', $css );
+			$css = preg_replace( '/([\{\}:=,\(*\/!;>])\s/', '$1', $css );
+		}
+		return $css;
+	}
 
-    /*=============================================================
-     * CSS 内の未使用 id, class, tag に関する定義を取り除く縮小化
-     */
-    public static function extended_minify($css, $html, $jsaddlist=array()) {
-        self::$atrule_data = array();
-        self::$jsaddlist = $jsaddlist;  //JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
-        $inidata = array(
+	/*
+	=============================================================
+	 * CSS 内の未使用 id, class, tag に関する定義を取り除く縮小化
+	 */
+	public static function extended_minify( $css, $html, $jsaddlist = array() ) {
+		self::$atrule_data = array();
+		self::$jsaddlist   = $jsaddlist;  // JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
+		$inidata           = array(
 			'id'    => array(),
 			'class' => array(
 				'device-mobile',
@@ -181,10 +206,10 @@ class CSS_tree_shaking {
 				'carousel-item-left',
 				'carousel-item-next',
 				'carousel-item-right',
-                'carousel-item-prev',
-                'form-control',
-                'btn',
-                'btn-primary',
+				'carousel-item-prev',
+				'form-control',
+				'btn',
+				'btn-primary',
 				'.vk_post_imgOuter a:hover .card-img-overlay::after',
 			),
 			'tag'   => array(
@@ -196,35 +221,38 @@ class CSS_tree_shaking {
 				'meta',
 				'link',
 				'script',
-				'noscript'
-			)
+				'noscript',
+			),
 		);
-		$inidata = apply_filters( 'css_tree_shaking_exclude', $inidata );
-        $pattern = array( 'id'    => '|[\s\t\'"]id\s?=\s?[\'"](.+?)[\'"]|u',
-                          'class' => '|[\s\t\'"]class\s?=\s?[\'"](.+?)[\'"]|u',
-                          'tag'   => '|<([\w\-]+)|iu'
-                        );
+		$inidata           = apply_filters( 'css_tree_shaking_exclude', $inidata );
+		$pattern           = array(
+			'id'    => '|[\s\t\'"]id\s?=\s?[\'"](.+?)[\'"]|u',
+			'class' => '|[\s\t\'"]class\s?=\s?[\'"](.+?)[\'"]|u',
+			'tag'   => '|<([\w\-]+)|iu',
+		);
 
-        if(empty(self::$cmplist['parse'])){
-            self::$cmplist['parse'] = true;
-            foreach (array('id','class','tag') as $item) {
-                self::$cmplist[$item] = $inidata[$item];
-                if(preg_match_all( $pattern[$item], $html, $matches)){
-                    foreach ($matches[1] as $val) {
-                        $arr = array_map("trim", explode(' ', $val));
-                        foreach($arr as $dt){
-                            if(!empty($dt) && !in_array($dt, self::$cmplist[$item]))
-                                self::$cmplist[$item][] = $dt;
-                        }
-                    }
-                }
-            }
-        }
-        $css = self::simple_minify( $css );
-        $css = self::atrule_store( $css );
-        $css = self::tree_shaking( $css );
-        $css = self::atrule_restore( $css );
-        $css = self::tree_shaking4var( $css );
-        return $css;
-    }
+		if ( empty( self::$cmplist['parse'] ) ) {
+			self::$cmplist['parse'] = true;
+			foreach ( array( 'id', 'class', 'tag' ) as $item ) {
+				self::$cmplist[ $item ] = $inidata[ $item ];
+				if ( preg_match_all( $pattern[ $item ], $html, $matches ) ) {
+					foreach ( $matches[1] as $val ) {
+						$arr = array_map( 'trim', explode( ' ', $val ) );
+						foreach ( $arr as $dt ) {
+							if ( ! empty( $dt ) && ! in_array( $dt, self::$cmplist[ $item ] ) ) {
+								self::$cmplist[ $item ][] = $dt;
+							}
+						}
+					}
+				}
+			}
+		}
+		$css = self::simple_minify( $css );
+		$css = self::atrule_store( $css );
+		$css = self::tree_shaking( $css );
+		$css = self::atrule_restore( $css );
+		// 変数のTreeshaking は必要なのに除外されてしまうので停止
+		// $css = self::tree_shaking4var( $css );
+		return $css;
+	}
 }

--- a/_g2/inc/vk-css-optimize/package/class-vk-css-optimize.php
+++ b/_g2/inc/vk-css-optimize/package/class-vk-css-optimize.php
@@ -11,10 +11,6 @@ https://github.com/vektor-inc/vektor-wp-libraries
 If you want to change this file, please change the original file.
 */
 
-
-/**
- * VK CSS Optimize
- */
 if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 	/**
 	 * VK CSS Optimize

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -189,7 +189,11 @@ function lightning_load_common_editor_css() {
 	/*
 	 Notice : Use url then if you use local environment https has error that bring to get css error and don't refrected */
 	/* Notice : add_editor_style() is only one args. */
-	add_editor_style( LIG_G3_DIR . '/assets/css/editor.css' );
+	/* add_editor_style is for Classic Editor Only. */
+	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
+	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
+		add_editor_style( LIG_G3_DIR . '/assets/css/editor.css' );
+	}
 }
 
 /*

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -191,7 +191,6 @@ function lightning_load_common_editor_css() {
 	/* Notice : add_editor_style() is only one args. */
 	/* add_editor_style is for Classic Editor Only. */
 	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
-	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
 		add_editor_style( LIG_G3_DIR . '/assets/css/editor.css' );
 	}
 }

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -184,13 +184,14 @@ function lightning_theme_style() {
 /*
   Load Editor CSS
 /*-------------------------------------------*/
-add_action( 'after_setup_theme', 'lightning_load_common_editor_css' );
+add_action( 'admin_enqueue_scripts', 'lightning_load_common_editor_css' );
 function lightning_load_common_editor_css() {
 	/*
 	 Notice : Use url then if you use local environment https has error that bring to get css error and don't refrected */
 	/* Notice : add_editor_style() is only one args. */
 	/* add_editor_style is for Classic Editor Only. */
-	if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post ) ) {
+	global $post;
+	if ( ! function_exists( 'use_block_editor_for_post' ) || ! use_block_editor_for_post( $post ) ) {
 		add_editor_style( LIG_G3_DIR . '/assets/css/editor.css' );
 	}
 }

--- a/_g3/inc/class-design-manager.php
+++ b/_g3/inc/class-design-manager.php
@@ -11,13 +11,15 @@ class Lightning_Design_Manager {
 
 		add_action( 'wp', array( __CLASS__, 'load_skin_callback' ) );
 
-		// Don't use following action point.
-		// wp : become do not load css.
-		add_action( 'after_setup_theme', array( __CLASS__, 'load_skin_editor_css' ) );
 
 		add_action( 'customize_register', array( __CLASS__, 'customize_register' ) );
 
-		// This method is planned to be removed.
+		/**
+		 * 編集画面において enqueue_block_editor_assets は上部で add_editor_style は下部で読み込まれる
+		 * -> 両方書くと enqueue_block_editor_assets で定義した CSS に wp_add_inline_style で引っ掛けても効かない
+		 * -> add_editor_style は Classic Editor 専用にすることで解決
+		 */
+		add_action( 'after_setup_theme', array( __CLASS__, 'load_skin_editor_css' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'load_skin_gutenberg_css' ) );
 
 	}

--- a/_g3/inc/customize/customize-design.php
+++ b/_g3/inc/customize/customize-design.php
@@ -137,4 +137,5 @@ function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css, 11 );
 }
+// 11 指定が無いと先に読み込んでしまって効かない
 add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );

--- a/_g3/inc/customize/customize-design.php
+++ b/_g3/inc/customize/customize-design.php
@@ -137,4 +137,4 @@ function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
 	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
 }
-add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor' );
+add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );

--- a/_g3/inc/customize/customize-design.php
+++ b/_g3/inc/customize/customize-design.php
@@ -135,6 +135,6 @@ add_action( 'wp_enqueue_scripts', 'lightning_add_common_dynamic_css', 11 );
 
 function lightning_add_common_dynamic_css_to_editor() {
 	$dynamic_css = lightning_get_common_inline_css();
-	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css );
+	wp_add_inline_style( 'lightning-common-editor-gutenberg', $dynamic_css, 11 );
 }
 add_action( 'enqueue_block_editor_assets', 'lightning_add_common_dynamic_css_to_editor', 11 );

--- a/_g3/inc/vk-css-optimize/package/class-css-tree-shaking.php
+++ b/_g3/inc/vk-css-optimize/package/class-css-tree-shaking.php
@@ -11,9 +11,9 @@ If you want to change this file, please change the original file.
  *
  * Version: 1.0.2
  * Author: enomoto@celtislab
+ * Modefied: Vektor:Inc.
  * Author URI: https://celtislab.net/
  * License: GPLv2
- *
  */
 namespace celtislab;
 
@@ -21,149 +21,174 @@ defined( 'ABSPATH' ) || exit;
 
 class CSS_tree_shaking {
 
-    private static $cmplist;
-    private static $varlist;
-    private static $jsaddlist;
-    private static $atrule_data;
+	private static $cmplist;
+	private static $varlist;
+	private static $jsaddlist;
+	private static $atrule_data;
 	function __construct() {}
 
-    // アットルール一時退避( @{md5key} に置き換えておく)
-    private static function atrule_store($css){
-        $pattern = array( '|(@(\-[\w]+\-)?keyframes.+?\{)(.+?\})\}|',
-                          '|(@(\-[\w]+\-)?supports.+?\{)(.+?\})\}|',
-                          '|(@(\-[\w]+\-)?media.+?\{)(.+?\})\}|',
-                          '|@[^;\{]+?;|',
-                          '|@[^;\{]+?\{(.+?)\}|'
-                        );
-        foreach ( $pattern as $atrule ) {
-            $css = preg_replace_callback( $atrule, function($matches) {
-                $key = 'AR_' . md5($matches[0]);
-                $data = $matches[0];
-                if(!empty($matches[3])){
-                    $incss = self::atrule_store( $matches[3] );
-                    $incss = self::tree_shaking( $incss );
-                    $data = (!empty($incss))? $matches[1] . $incss . '}' : '';
-                }
-               	self::$atrule_data[ $key ] = $data;
-                return '@{' . $key . '}';
-            }, $css);
-        }
-        return $css;
-    }
+	// アットルール一時退避( @{md5key} に置き換えておく)
+	private static function atrule_store( $css ) {
+		$pattern = array(
+			'|(@(\-[\w]+\-)?keyframes.+?\{)(.+?\})\}|',
+			'|(@(\-[\w]+\-)?supports.+?\{)(.+?\})\}|',
+			'|(@(\-[\w]+\-)?media.+?\{)(.+?\})\}|',
+			'|@[^;\{]+?;|',
+			'|@[^;\{]+?\{(.+?)\}|',
+		);
+		foreach ( $pattern as $atrule ) {
+			$css = preg_replace_callback(
+				$atrule,
+				function( $matches ) {
+					$key  = 'AR_' . md5( $matches[0] );
+					$data = $matches[0];
+					if ( ! empty( $matches[3] ) ) {
+						$incss = self::atrule_store( $matches[3] );
+						$incss = self::tree_shaking( $incss );
+						$data  = ( ! empty( $incss ) ) ? $matches[1] . $incss . '}' : '';
+					}
+					self::$atrule_data[ $key ] = $data;
+					return '@{' . $key . '}';
+				},
+				$css
+			);
+		}
+		return $css;
+	}
 
-    //アットルール復元
-    private static function atrule_restore($css){
-        $css = preg_replace_callback('|@\{(.+?)\}|', function($matches) {
-            $data = $matches[0];
-            $key = $matches[1];
-            if(strpos($key, 'AR_') !== false){
-                $data = (!empty(self::$atrule_data[ $key ]))? self::atrule_restore( self::$atrule_data[ $key ] ) : '';
-            }
-            return $data;
-        }, $css);
-        return $css;
-    }
+	// アットルール復元
+	private static function atrule_restore( $css ) {
+		$css = preg_replace_callback(
+			'|@\{(.+?)\}|',
+			function( $matches ) {
+				$data = $matches[0];
+				$key  = $matches[1];
+				if ( strpos( $key, 'AR_' ) !== false ) {
+					$data = ( ! empty( self::$atrule_data[ $key ] ) ) ? self::atrule_restore( self::$atrule_data[ $key ] ) : '';
+				}
+				return $data;
+			},
+			$css
+		);
+		return $css;
+	}
 
-    //CSS から未使用の id, class, tag を含む定義を削除
-    private static function tree_shaking($css) {
-        $ncss = preg_replace_callback("|(.+?)(\{.+?\})|u", function($matches) {
-            $data = $matches[0];
-            $sel = $matches[1];
-            if($sel !== '@'){
-                $pattern = array( 'id'    => '|(#)([\w\-\\%]+)|u',
-                                  'class' => '|(\.)([\w\-\\%]+)|u',
-                                  'tag'   => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu'
-                                );
+	// CSS から未使用の id, class, tag を含む定義を削除
+	private static function tree_shaking( $css ) {
+		$ncss = preg_replace_callback(
+			'|(.+?)(\{.+?\})|u',
+			function( $matches ) {
+				$data = $matches[0];
+				$sel  = $matches[1];
+				if ( $sel !== '@' ) {
+					$pattern = array(
+						'id'    => '|(#)([\w\-\\%]+)|u',
+						'class' => '|(\.)([\w\-\\%]+)|u',
+						'tag'   => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu',
+					);
 
-                $slist = array_map("trim", explode(',', $sel));
-                foreach ($slist as $s) {
-                    //selector の判定条件から :not(...) を除外 ($_s で判定して削除時は $s で行う)
-                    $_s = $s;
-                    if(preg_match('/:not\(.+?\)/', $s)){
-                        $_s = preg_replace( '/:not\(.+?\)/', '', $s );
-                    }
-                    foreach (array('id','class','tag') as $item) {
-                        if(!empty($_s) && preg_match_all( $pattern[$item], $_s, $match)){
-                            foreach ($match[2] as $val) {
-                                //$jsaddlist 登録名が一部でも含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
-                                if(in_array($val, self::$jsaddlist))
-                                    break;
+					$slist = array_map( 'trim', explode( ',', $sel ) );
+					foreach ( $slist as $s ) {
+						// selector の判定条件から :not(...) を除外 ($_s で判定して削除時は $s で行う)
+						$_s = $s;
+						if ( preg_match( '/:not\(.+?\)/', $s ) ) {
+							$_s = preg_replace( '/:not\(.+?\)/', '', $s );
+						}
+						foreach ( array( 'id', 'class', 'tag' ) as $item ) {
+							if ( ! empty( $_s ) && preg_match_all( $pattern[ $item ], $_s, $match ) ) {
+								foreach ( $match[2] as $val ) {
+									// $jsaddlist 登録名が一部でも含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
+									if ( in_array( $val, self::$jsaddlist ) ) {
+										break;
+									}
 
-                                //$cmplist 登録名に含まれていないものが一つでもあれば削除
-                                if(!preg_match('/^[0-9]+/', $val) && !in_array($val, self::$cmplist[$item])){
-                                    $sel = preg_replace( '/(' . preg_quote($s) . ')(,|$)/u', '$2', $sel, 1 );
-                                    $s = '';
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                $sel = preg_replace('/,+/su', ',', $sel);
-                $sel = preg_replace('/\s+/su', ' ', $sel);
-                $sel = trim($sel);
-                $sel = trim($sel, ',');
-                $data = (!empty($sel))? $sel . $matches[2] : '';
-            }
-            return $data;
-        }, $css);
-        return $ncss;
-    }
+									// $cmplist 登録名に含まれていないものが一つでもあれば削除
+									if ( ! preg_match( '/^[0-9]+/', $val ) && ! in_array( $val, self::$cmplist[ $item ] ) ) {
+										$sel = preg_replace( '/(' . preg_quote( $s ) . ')(,|$)/u', '$2', $sel, 1 );
+										$s   = '';
+										break;
+									}
+								}
+							}
+						}
+					}
+					$sel  = preg_replace( '/,+/su', ',', $sel );
+					$sel  = preg_replace( '/\s+/su', ' ', $sel );
+					$sel  = trim( $sel );
+					$sel  = trim( $sel, ',' );
+					$data = ( ! empty( $sel ) ) ? $sel . $matches[2] : '';
+				}
+				return $data;
+			},
+			$css
+		);
+		return $ncss;
+	}
 
-    //未使用変数定義の削除（tree_shaking 実行後に実施する必要あり）
-    public static function tree_shaking4var($css) {
-        $ncss = $css;
-        self::$varlist = array();
-        if(preg_match_all( '/var\((\-\-.+?)\)/iu', $css, $vmatchs)){
-            foreach ($vmatchs[1] as $v) {
-                $v = trim($v);
-                if(!in_array($v, self::$varlist)){
-                    self::$varlist[] = $v;
-                }
-            }
-        }
-        //url() 定義時は文字列中に ; がそのまま含まれている場合があるの分けて処理
-        $ncss = preg_replace_callback( '|(\-\-[\w\-]+?):url\(.+?\);?|u', function($matches) {
-            $data = $matches[0];
-            if(!in_array(trim($matches[1]), self::$varlist)){
-                $data = '';
-            }
-            return $data;
-        }, $ncss);
-        $ncss = preg_replace_callback( '|(\-\-[\w\-]+?):(.+?)([;\}])|u', function($matches) {
-            $data = $matches[0];
-            if(!preg_match('|url\(|u', $matches[2]) && !in_array(trim($matches[1]), self::$varlist)){
-                $data = ($matches[3] === '}')? '}' : '';
-            }
-            return $data;
-        }, $ncss);
+	// 未使用変数定義の削除（tree_shaking 実行後に実施する必要あり）
+	public static function tree_shaking4var( $css ) {
+		$ncss          = $css;
+		self::$varlist = array();
+		if ( preg_match_all( '/var\((\-\-.+?)\)/iu', $css, $vmatchs ) ) {
+			foreach ( $vmatchs[1] as $v ) {
+				$v = trim( $v );
+				if ( ! in_array( $v, self::$varlist ) ) {
+					self::$varlist[] = $v;
+				}
+			}
+		}
+		// url() 定義時は文字列中に ; がそのまま含まれている場合があるの分けて処理
+		$ncss = preg_replace_callback(
+			'|(\-\-[\w\-]+?):url\(.+?\);?|u',
+			function( $matches ) {
+				$data = $matches[0];
+				if ( ! in_array( trim( $matches[1] ), self::$varlist ) ) {
+					$data = '';
+				}
+				return $data;
+			},
+			$ncss
+		);
+		$ncss = preg_replace_callback(
+			'|(\-\-[\w\-]+?):(.+?)([;\}])|u',
+			function( $matches ) {
+				$data = $matches[0];
+				if ( ! preg_match( '|url\(|u', $matches[2] ) && ! in_array( trim( $matches[1] ), self::$varlist ) ) {
+					$data = ( $matches[3] === '}' ) ? '}' : '';
+				}
+				return $data;
+			},
+			$ncss
+		);
 
-        return $ncss;
-    }
+		return $ncss;
+	}
 
-    /*=============================================================
-     * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
-     */
-    public static function simple_minify( $css ) {
-        $res = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
-        if(!empty($res)){
-            $css = $res;
-            $css = str_replace(array("\r", "\n"), '', $css);
-            $css = str_replace("\t", ' ', $css);
-            $css = preg_replace('/\s+/su', ' ', $css);
-            $css = preg_replace('/\s([\{\}:=,\)*\/;>])/', '$1', $css);
-            $css = preg_replace('/([\{\}:=,\(*\/!;>])\s/', '$1', $css);
-        }
-        return $css;
-    }
+	/*
+	=============================================================
+	 * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
+	 */
+	public static function simple_minify( $css ) {
+		$res = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
+		if ( ! empty( $res ) ) {
+			$css = $res;
+			$css = str_replace( array( "\r", "\n" ), '', $css );
+			$css = str_replace( "\t", ' ', $css );
+			$css = preg_replace( '/\s+/su', ' ', $css );
+			$css = preg_replace( '/\s([\{\}:=,\)*\/;>])/', '$1', $css );
+			$css = preg_replace( '/([\{\}:=,\(*\/!;>])\s/', '$1', $css );
+		}
+		return $css;
+	}
 
-    /*=============================================================
-     * CSS 内の未使用 id, class, tag に関する定義を取り除く縮小化
-     */
-    public static function extended_minify($css, $html, $jsaddlist=array()) {
-        self::$atrule_data = array();
-        self::$jsaddlist = $jsaddlist;  //JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
-        $inidata = array(
+	/*
+	=============================================================
+	 * CSS 内の未使用 id, class, tag に関する定義を取り除く縮小化
+	 */
+	public static function extended_minify( $css, $html, $jsaddlist = array() ) {
+		self::$atrule_data = array();
+		self::$jsaddlist   = $jsaddlist;  // JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
+		$inidata           = array(
 			'id'    => array(),
 			'class' => array(
 				'device-mobile',
@@ -181,10 +206,10 @@ class CSS_tree_shaking {
 				'carousel-item-left',
 				'carousel-item-next',
 				'carousel-item-right',
-                'carousel-item-prev',
-                'form-control',
-                'btn',
-                'btn-primary',
+				'carousel-item-prev',
+				'form-control',
+				'btn',
+				'btn-primary',
 				'.vk_post_imgOuter a:hover .card-img-overlay::after',
 			),
 			'tag'   => array(
@@ -196,35 +221,38 @@ class CSS_tree_shaking {
 				'meta',
 				'link',
 				'script',
-				'noscript'
-			)
+				'noscript',
+			),
 		);
-		$inidata = apply_filters( 'css_tree_shaking_exclude', $inidata );
-        $pattern = array( 'id'    => '|[\s\t\'"]id\s?=\s?[\'"](.+?)[\'"]|u',
-                          'class' => '|[\s\t\'"]class\s?=\s?[\'"](.+?)[\'"]|u',
-                          'tag'   => '|<([\w\-]+)|iu'
-                        );
+		$inidata           = apply_filters( 'css_tree_shaking_exclude', $inidata );
+		$pattern           = array(
+			'id'    => '|[\s\t\'"]id\s?=\s?[\'"](.+?)[\'"]|u',
+			'class' => '|[\s\t\'"]class\s?=\s?[\'"](.+?)[\'"]|u',
+			'tag'   => '|<([\w\-]+)|iu',
+		);
 
-        if(empty(self::$cmplist['parse'])){
-            self::$cmplist['parse'] = true;
-            foreach (array('id','class','tag') as $item) {
-                self::$cmplist[$item] = $inidata[$item];
-                if(preg_match_all( $pattern[$item], $html, $matches)){
-                    foreach ($matches[1] as $val) {
-                        $arr = array_map("trim", explode(' ', $val));
-                        foreach($arr as $dt){
-                            if(!empty($dt) && !in_array($dt, self::$cmplist[$item]))
-                                self::$cmplist[$item][] = $dt;
-                        }
-                    }
-                }
-            }
-        }
-        $css = self::simple_minify( $css );
-        $css = self::atrule_store( $css );
-        $css = self::tree_shaking( $css );
-        $css = self::atrule_restore( $css );
-        $css = self::tree_shaking4var( $css );
-        return $css;
-    }
+		if ( empty( self::$cmplist['parse'] ) ) {
+			self::$cmplist['parse'] = true;
+			foreach ( array( 'id', 'class', 'tag' ) as $item ) {
+				self::$cmplist[ $item ] = $inidata[ $item ];
+				if ( preg_match_all( $pattern[ $item ], $html, $matches ) ) {
+					foreach ( $matches[1] as $val ) {
+						$arr = array_map( 'trim', explode( ' ', $val ) );
+						foreach ( $arr as $dt ) {
+							if ( ! empty( $dt ) && ! in_array( $dt, self::$cmplist[ $item ] ) ) {
+								self::$cmplist[ $item ][] = $dt;
+							}
+						}
+					}
+				}
+			}
+		}
+		$css = self::simple_minify( $css );
+		$css = self::atrule_store( $css );
+		$css = self::tree_shaking( $css );
+		$css = self::atrule_restore( $css );
+		// 変数のTreeshaking は必要なのに除外されてしまうので停止
+		// $css = self::tree_shaking4var( $css );
+		return $css;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Lightning WordPress theme, Copyright (C) 2015-2021 Vektor,Inc.
 Lightning WordPress theme is licensed under the GPL.
 Tested up to: 5.7.1
-Stable tag: 14.2.1
+Stable tag: 14.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,9 @@ https://www.vektor-inc.co.jp/inquiry/
 
 
 == Changelog ==
+
+v14.2.2
+[ G3 ][ Bug fix ] Fix archive title PHP critical error
 
 v14.2.1
 [ G3 ][ Bug fix ] Fix Bread Crumb under case of post top page is not specificated

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Lightning ===
 Lightning WordPress theme, Copyright (C) 2015-2021 Vektor,Inc.
 Lightning WordPress theme is licensed under the GPL.
-Tested up to: 5.7.1
-Stable tag: 14.2.2
+Tested up to: 5.7.2
+Stable tag: 14.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,9 @@ https://www.vektor-inc.co.jp/inquiry/
 
 
 == Changelog ==
+
+v14.2.3
+[ Specification Change ] Stop exclude CSS Var by Tree shaking
 
 v14.2.2
 [ G3 ][ Bug fix ] Fix archive title PHP critical error

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Theme URI: https://lightning.nagoya
 Description: Lightning is a very simple & easy to customize theme which is based on the Bootstrap. It is also very friendly with custom post types and custom taxonomies. When you add a new one, the breadcrumbs will be adjusted and posts will look beautifully without editing or adding a template files.
 Author: Vektor,Inc.
 Author URI: https://www.vektor-inc.co.jp
-Version: 14.2.1
+Version: 14.2.2
 Requires at least: 5.3
 Tested up to: 5.7.0
 Requires PHP: 5.6.0

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Theme URI: https://lightning.nagoya
 Description: Lightning is a very simple & easy to customize theme which is based on the Bootstrap. It is also very friendly with custom post types and custom taxonomies. When you add a new one, the breadcrumbs will be adjusted and posts will look beautifully without editing or adding a template files.
 Author: Vektor,Inc.
 Author URI: https://www.vektor-inc.co.jp
-Version: 14.2.2
+Version: 14.2.3
 Requires at least: 5.3
 Tested up to: 5.7.0
 Requires PHP: 5.6.0


### PR DESCRIPTION
【現状の問題点と解決策】
- 編集画面において ```enqueue_block_editor_assets``` は上部で ```add_editor_style``` は下部で読み込まれる
⇒両方書くと ```enqueue_block_editor_assets``` にで定義した CSS に ```wp_add_inline_style``` で引っ掛けても効かない
⇒```add_editor_style``` は Classic Editor 専用にすることで解決

---

【確認条件】
- プラグインを無効化した状態でテーマを Lightning にして確認

---

【確認事項】
- 編集画面でキーカラーが効くか否か

