### PR TITLE
スキン の CSS は Minify & インライン展開のみ適応

### DIFF
--- a/_g3/inc/vk-css-optimize/config.php
+++ b/_g3/inc/vk-css-optimize/config.php
@@ -44,7 +44,7 @@ function lightning_css_tree_shaking_array( $vk_css_tree_shaking_array ) {
 	}
 	return $vk_css_tree_shaking_array;
 }
-add_filter( 'vk_css_tree_shaking_array', 'lightning_css_tree_shaking_array' );
+add_filter( 'vk_css_simple_minify_array', 'lightning_css_tree_shaking_array' );
 
 
 /**


### PR DESCRIPTION
CSS の不要な部分を削除する Tree Shaking は闇が深そうなので
スキンの CSS は Tree Shaking は適用せず Minify & インライン展開のみ適用するよう変更しました。

P.S,

普段プルリクを出すブランチは develop ブランチなのでデフォルトブランチを develop に変更してみました。