### PR TITLE
【確認待ち】ウィジェット編集画面で lightning-js が読まれないように変更

### DIFF
--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -199,12 +199,13 @@ function lightning_add_script() {
 		return;
 	}
 	// 現在の URL を取得
-	$current_url = parse_url( $_SERVER["REQUEST_URI"] );
+	$current_url = parse_url( $_SERVER["REQUEST_URI"], PHP_URL_SCHEME );
+	$admin_url   = parse_url( admin_url() );
 	if ( 
 		// 現在の URL に widgets.php が含まれる
-		false !== strpos( $current_url, 'widgets.php' ) && 
+		false !== strpos( $current_url['path'], 'widgets.php' ) && 
 		// 現在の URL に 管理画面の URL が含まれる
-		false !== strpos( $current_url, admin_url() ) 
+		false !== strpos( $current_url['path'], admin_url() ) 
 	) {
 		return;
 	}

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -198,10 +198,11 @@ function lightning_add_script() {
 	if ( filter_input( INPUT_GET, 'legacy-widget-preview', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ) ) {
 		return;
 	}
-	global $pagenow;
-	if ( 'widgets.php' === $pagenow ) {
+	$current_path = parse_url( $_SERVER["REQUEST_URI"]['path'] );
+	if ( false !== strpos( $current_path, 'widgets.php' ) ) {
 		return;
 	}
+	
 	wp_register_script( 'lightning-js', get_template_directory_uri() . '/assets/js/main.js', array(), LIGHTNING_THEME_VERSION, true );
 	wp_localize_script( 'lightning-js', 'lightningOpt', apply_filters( 'lightning_localize_options', array() ) );
 	wp_enqueue_script( 'lightning-js' );

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -198,8 +198,14 @@ function lightning_add_script() {
 	if ( filter_input( INPUT_GET, 'legacy-widget-preview', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ) ) {
 		return;
 	}
-	$current_path = parse_url( $_SERVER["REQUEST_URI"]['path'] );
-	if ( false !== strpos( $current_path, 'widgets.php' ) ) {
+	// 現在の URL を取得
+	$current_url = parse_url( $_SERVER["REQUEST_URI"] );
+	if ( 
+		// 現在の URL に widgets.php が含まれる
+		false !== strpos( $current_url, 'widgets.php' ) && 
+		// 現在の URL に 管理画面の URL が含まれる
+		false !== strpos( $current_url, admin_url() ) 
+	) {
 		return;
 	}
 	

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -198,15 +198,11 @@ function lightning_add_script() {
 	if ( filter_input( INPUT_GET, 'legacy-widget-preview', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ) ) {
 		return;
 	}
-	// 現在の URL を取得
-	$current_url = parse_url( $_SERVER["REQUEST_URI"], PHP_URL_SCHEME );
-	$admin_url   = parse_url( admin_url() );
-	if ( 
-		// 現在の URL に widgets.php が含まれる
-		false !== strpos( $current_url['path'], 'widgets.php' ) && 
-		// 現在の URL に 管理画面の URL が含まれる
-		false !== strpos( $current_url['path'], admin_url() ) 
-	) {
+	global $pagenow;
+	if ( 'widgets.php' === $pagenow ) {
+		return;
+	}
+	if ( 'index.php' === $pagenow && false !== strpos( $_SERVER['REQUEST_URI'], 'rest_route' ) ) {
 		return;
 	}
 	

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ Bug fix ] No Read Lightning Scripts on widget editor scrren.
+
 v14.19.0
 [ G3 ][ Specification Change ] Delete table bottom margin
 [ G3 /G2 ][ Design tuning ] wooCommerce Design Tuning


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/lightning/issues/809

## どういう変更をしたか？

- wp-admin/widget.php を開いたときに lightning-js が読まれないように変更しました。
- セキュリティ面で  wp-admin のパス名を変えていることも想定し判定には admin_url() も採用しました。　

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

ウィジェット編集画面で lightning-js が読み込まれなくなったことを確認しました。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

以下の確認をお願いします。
- ウィジェット編集画面で lightning-js が読み込まれなくなったこと
- コードレビュー

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
