### PR TITLE
【確認待ち】タブレットサイズ以下でサイトタイトルテキストが長い場合見切れてしまうので追加

### DIFF
--- a/_g3/assets/_scss/project/_site-header.scss
+++ b/_g3/assets/_scss/project/_site-header.scss
@@ -24,6 +24,7 @@ $logo_bottom_margin:1rem;
             */
             padding-top:0.5rem; 
             margin-bottom:0.5rem;
+            white-space: normal; //タブレットサイズ以下でサイトタイトルテキストが長い場合見切れてしまうので追加
             img {
                 max-height:50px;
             }


### PR DESCRIPTION
そのままマージしていただいてもいいくらいの微修正です。

https://github.com/vektor-inc/lightning/issues/710

タブレットサイズ以下の場合に、テキストが折り返すように`white-space: normal;`を追加しました。
.site-header-logo{
@media ( max-width: $md-max ){
`white-space: normal;`
}
}