### PR TITLE
[ G2 ][ Bug fix ] Fix fatal error arise from bootstrap version version judgement on slider

### DIFF
--- a/_g2/front-page.php
+++ b/_g2/front-page.php
@@ -3,7 +3,8 @@
 <?php
 do_action( 'lightning_top_slide_before' );
 if ( empty( $lightning_theme_options['top_slide_hide'] ) ) {
-	if ( $bootstrap == '3' ) {
+	global $bootstrap;
+	if ( '3' === $bootstrap || 3 === $bootstrap ) {
 		$old_file_name   = array();
 		$old_file_name[] = 'module_slide.php';
 		if ( locate_template( $old_file_name, false, false ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ G2 ][ Bug fix ] Fix fatal error arise from bootstrap version version judgement on slider
+
 v15.9.2
 [ G3 ][ Bug fix ] Fixed file reference bug of slider under specific environment such as Windows ( Update Swiper 9.3.2 )
 


### PR DESCRIPTION
あー、
G3 から G2 に変更した時にリロードしてない時だけ $bootstrap の判定失敗するとかそんな感じっぽい。