### PR TITLE
[ G3 (no-theme.json) ] Support link color and border.

### DIFF
--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -24,6 +24,9 @@ function lightning_theme_setup() {
 	add_theme_support( 'customize-selective-refresh-widgets' );
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'woocommerce' );
+	// theme.json deactive support //////////////////////////////////.
+	add_theme_support( 'link-color' );
+	add_theme_support( 'border' );
 
 	// When this support that printed front css and it's overwrite skin table style and so on
 	// add_theme_support( 'wp-block-styles' );.

--- a/_theme.json
+++ b/_theme.json
@@ -2,6 +2,11 @@
 	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
 	"version": 2,
 	"settings": {
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
 		"spacing": {
 			"blockGap": true,
 			"margin": true,

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
-[ G3 / G2 ][ Specification change ] Changed to get bbpress topic title from bbp_get_topic_title
+[ G3 (no-theme.json) ] Support link color and border.
+[ G3 / G2 ][ Specification change ] Changed to get bbpress topic title from bbp_get_topic_title.
 
 v15.9.5
 [ G3 / G2 ][ Bug Fix ] Fix VK_Helpers::color_auto_modifi() 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://wp.me/p2AvED-rDu

## どういう変更をしたか？

theme.json 有効でなくとも リンクカラーの設定と線の設定が使えるように
