### PR TITLE
lightning_get_entry_meta の author 取得処理修正

### DIFF
--- a/_g3/inc/template-tags.php
+++ b/_g3/inc/template-tags.php
@@ -339,8 +339,16 @@ function lightning_get_entry_meta( $options = array() ) {
 		if ( $option['author_name'] || $option['author_image'] ) {
 			// Post author
 			// For post type where author does not exist.
-			// get_the_author() がページヘッダーの段階で効いていなかったので少し遠回り
-			$author = get_userdata( get_post( get_the_id() )->post_author )->display_name;
+			// get_the_author() がページヘッダーで呼び出された時に効かないので、取得失敗した場合は一度 the_post() で取得する.
+			$author = get_the_author();
+			if ( ! $author ) {
+				if ( have_posts() ) :
+					while ( have_posts() ) :
+						the_post();
+						$author = get_the_author();
+					endwhile;
+				endif;
+			}
 			if ( $author ) {
 				$meta_hidden_author = ( ! empty( $options['postAuthor_hidden'] ) ) ? ' entry-meta_hidden' : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ G3 ][ Bugfix ] Fix lightning_get_entry_meta function.
+
 v15.10.1
 [ G3 ][ Improvement ] Improvement to hide the fixed header when clicking on an anchor link URL from another page.
 [ G3 ][ Bugfix ] Fix lightning_get_entry_meta function.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

 VK Blocks Pro のユニットテストで 

1) Test_PHP_Fatal_Error::test_run_php_fatal_error
Trying to get property 'display_name' of non-object

くらうため、the_post() 経由するように修正