### PR TITLE
[ G3 ] 投稿 本文下部 タクソノミーリストにタクソノミー識別クラスを追加

### DIFF
--- a/_g3/template-parts/entry.php
+++ b/_g3/template-parts/entry.php
@@ -82,7 +82,7 @@ if ( is_page() ) {
 
 					<?php
 					foreach ( $taxonomies as $key => $value ) {
-						$taxnomies_html .= '<div class="entry-meta-data-list">' . $value . '</div>';
+						$taxnomies_html .= '<div class="entry-meta-data-list ' . $key . '">' . $value . '</div>';
 					} // foreach
 
 					$taxnomies_html = apply_filters( 'lightning_taxnomiesHtml', $taxnomies_html ); // phpcs:ignore
@@ -92,7 +92,7 @@ if ( is_page() ) {
 					$tags_list = get_the_tag_list();
 					if ( $tags_list ) {
 						?>
-						<div class="entry-meta-data-list">
+						<div class="entry-meta-data-list post_tag">
 							<dl>
 							<dt><?php esc_html_e( 'Tags', 'lightning' ); ?></dt>
 							<dd class="tagcloud"><?php echo wp_kses_post( $tags_list ); ?></dd>

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ G3 ][ Specification Change ] Add taxonomy name class to the post bottom taxonomy list.
+
 v15.12.1
 [ G3 ][ Fix ] Fixed the position of sidebar shortcut icon on the customize screen
 [ G3 ][ Fix ] Fixed the Widget edit UI on the customize screen


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/post-bottom-meta-taxonomy-list-class

## どういう変更をしたか？

投稿本文下 taxonomy リストにタクソノミー識別クラスを追加
