### PR TITLE
ページヘッダーの entry-meta の span タグに style を許可

### DIFF
--- a/_g3/template-parts/page-header.php
+++ b/_g3/template-parts/page-header.php
@@ -92,6 +92,7 @@ $allowed_html = array(
 	),
 	'span'   => array(
 		'class' => array(),
+		'style' => array(),
 	),
 	'img'    => array(
 		'class'   => array(),

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ G3 ] Allow style for the span tag in the entry-meta of the page header.
+
 v15.14.1
 [ G3 ] change footer copyright
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/page-header-entry-meta-allow-style

> ■ 期待する動作
> フィルターフックでカスタマイズして
> ページヘッダーの entry-meta の中に指定した style 属性が
> wp_kses によって除去されずに出力されるようにしてほしい。
> 
> 添付画像(1)をご参照ください。
> 
> ■ 自分で試した事
> /wp-content/themes/lightning/_g3/template-parts/page-header.php
> に以下の行を追加したら希望通りに出力されるようになりました。
> 
> 'style' => array(),
> 
> 添付画像(2)をご参照ください。
> 
> ■ その他特記事項
> カスタム投稿タイプ「賃貸物件」のカスタム分類「設備」を
> 物件名といっしょにページヘッダーに表示するカスタマイズを行っています。
> 
> カスタム分類「設備」に設定した色を style 属性により表示したいのですが、
> $allowed_html に ‘style’ が含まれていないために
> フックで指定した style 属性が除去されてしまいます。
> 
> page-header.php に 'style' => array(), を追加していただけると
> ありがたいです。
> 
> ご検討のほどよろしくお願いします。
> 

## どういう変更をしたか？

ページヘッダーの entry-meta の span タグに style を許可