### PR TITLE
G2 のeditor 画面の width 用の css を微修正

### DIFF
--- a/_g2/assets/_scss/block/_block_editor_width.scss
+++ b/_g2/assets/_scss/block/_block_editor_width.scss
@@ -8,6 +8,21 @@
 	--vk-width-editor-leftmenu-folded:36px;
 }
 
+// Begin Cope with 6.1 Group Block ( If 6.4 Release, Delete this code. )
+.editor-styles-wrapper .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
+	--wp--style--global--content-size:var(--vk-width-editor-container-body);
+}
+// End Cope width 6.1 Group Block
+
+.is-root-container,
+.edit-post-visual-editor__content-area .editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper > *, 
+.edit-post-visual-editor__content-area .editor-styles-wrapper .block-editor-block-list__layout.is-root-container > * {
+	width:var(--vk-width-editor-container-body);
+	max-width:var(--vk-width-editor-container-body);
+	margin-left:auto;
+	margin-right:auto;
+}
+
 // 左管理メニュー非表示 / 右サイドバー非表示
 body.is-fullscreen-mode .edit-post-layout:not(.is-sidebar-opened){
 	--vk-width-editor-full:100vw;
@@ -62,6 +77,11 @@ body.folded:not(.is-fullscreen-mode) .edit-post-layout.is-sidebar-opened{
 	.wp-block {
 		max-width:var(--vk-width-editor-container-body);
 	}
+	> .wp-block {
+		// 6.0 / theme.json あり / Evergreen のオフセット背景の時に左によってしまうため
+		margin-left:auto;
+		margin-right:auto;
+	}
 }
 
 /*****
@@ -89,47 +109,130 @@ div[data-align=full]
 
 */
 
-.editor-styles-wrapper .is-root-container {
-	& > .wp-block[data-align=full],
-	& > div[data-align=full]{
+html .edit-post-visual-editor :where(.editor-styles-wrapper) .block-editor-block-list__layout.is-root-container{
+
+	// Outer Element : Full /////////////////////////////////////////////////////////////
+	:is( 
+		.wp-block[data-align=full], 
+		.wp-block.alignfull, 
+		div[data-align=full], 
+		.vk_outer-width-full:where(:not(.vk_outer-paddingLR-zero,.vk_outer-paddingLR-use))
+		) {
+		box-sizing: border-box;
 		width:var(--vk-width-editor-full);
 		max-width:var(--vk-width-editor-full);
-		margin-left:-10px;
-		margin-right:-10px;
-		.wp-block[data-align=full]{
-			margin-left:0;
-			margin-right:0;
-		}
-		.alignfull {
-			width:var(--vk-width-editor-full);
-			margin-left:0;
-			margin-right:0;
+
+		// ! important をつけると vk_outer-paddingLR-use の中に全幅要素を配置した時 編集画面で表示が崩れる
+		margin-left: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 );
+		margin-right: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 );
+
+		// Outer ブロックの内側の余白機能は独特なので除外してインナー要素の全幅や幅広のネガティブマージンを指定する
+		&:where(:not(.vk_outer-paddingLR-zero,.vk_outer-paddingLR-use)){
+			:is( .wp-block[data-align=full], .wp-block.alignfull, div[data-align=full], .vk_outer-width-full ) {
+				// ! important をつけないと コアが 
+				// .editor-styles-wrapper .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
+				// 		max-width: var(--wp--style--global--content-size);
+				// 		margin-left: auto !important;
+				// 		margin-right: auto !important;
+				// }
+				// をつけてくるので負ける
+				margin-left: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 ) !important;
+				margin-right: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 ) !important;
+			}
+			:is( .wp-block[data-align=wide], .wp-block.alignwide, div[data-align=wide], .vk_outer-width-wide ) {
+				// ! important をつけないと コアが 
+				// .editor-styles-wrapper .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
+				// 		max-width: var(--wp--style--global--content-size);
+				// 		margin-left: auto !important;
+				// 		margin-right: auto !important;
+				// }
+				// をつけてくるので負ける
+				margin-left: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 ) !important;
+				margin-right: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 ) !important;
+			}
 		}
 	}
-	& > .wp-block[data-align=wide],
-	& > div[data-align=wide]{
+
+	// 通常サイズの中に幅広対策
+	:is(.wp-block-cover,.wp-block-group):not(.alignfull,.alignwide){
+		& > .is-layout-constrained [data-align=full] {
+			margin-left: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 ) !important;
+			margin-right: calc( var(--vk-width-editor-container-body) / 2 - var(--vk-width-editor-full) / 2 ) !important;
+		}
+		& > .is-layout-constrained [data-align=wide] {
+			margin-left: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 ) !important;
+			margin-right: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 ) !important;
+		}
+	}
+
+	// Outer Element : Wide /////////////////////////////////////////////////////////////
+	:is( .wp-block[data-align=wide], .wp-block.alignwide, div[data-align=wide] ){
 		width:var(--vk-width-editor-wide);
-		max-width:var(--vk-width-editor-wide);
-		margin-left:auto;
-		margin-right:auto;
+		max-width:var(--vk-width-editor-wide); // max-width も指定しておかないと上書きできない
+		// ! important をつけると vk_outer-paddingLR-use の中に全幅要素を配置した時 編集画面で表示が崩れる
+		margin-left: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 );
+		margin-right: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 );
 		.wp-block[data-align=wide]{
-			margin-left:0;
-			margin-right:0;
+			margin-left: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 );
+			margin-right: calc( ( var(--vk-width-editor-container-body) - var(--vk-width-editor-full) ) / 4 );
 		}
 		.alignwide{
 			width:var(--vk-width-editor-wide);
-			margin-left:auto;
-			margin-right:auto;
+			margin-left:auto !important;
+			margin-right:auto !important;
 		}
 	}
+
 	// __inner-container
 	& > .wp-block[data-align=full],
 	& > div[data-align=full],
 	& > .wp-block[data-align=wide],
 	& > div[data-align=wide]{
+		& > .wp-block-group > *, // theme.json があると __inner-container のdiv は出力されなくなってしまうので & > .wp-block-group > * を追加
 		& > div > div[class*="__inner-container"]{
-			width:var(--vk-width-editor-container);
-			max-width:var(--vk-width-editor-container);
+			width:var(--vk-width-editor-container-body);
+			max-width:var(--vk-width-editor-container-body);
+			margin-left:auto;
+			margin-right:auto;
+		}
+	}
+	.vk_outer-width-full {
+		&:not(:is(.vk_outer-paddingLR-zero,.vk_outer-paddingLR-use)) {
+			.vk_outer_container {
+				// max が 1140px 指定だったりするので広げる
+				max-width:var(--vk-width-editor-container-body);
+				padding-left:0;
+				padding-right:0;
+			}
+			.block-editor-inner-blocks{
+				max-width:var(--vk-width-editor-container-body);
+			}
+		}
+		// Outer固有の微妙な余白（左右それぞれ4em付与される）使用
+		&.vk_outer-paddingLR-use{
+			.vk_outer_container{
+				--vk-width-editor-container-body:calc( var(--vk-width-editor-full) -  8em );
+			}
+			:is(.wp-block[data-align=full] ){
+				width: auto;
+				margin-left: calc(50% - var(--vk-width-editor-full)/2);
+				margin-right: calc(50% - var(--vk-width-editor-full)/2);
+				max-width: var(--vk-width-editor-full);
+			}
+			:is(.wp-block[data-align=wide] ){
+				--vk-width-editor-wide : calc(var(--vk-width-editor-full) - 4em );
+				width:calc(var(--vk-width-editor-full) - 2em );
+				margin-left:-2em;
+				margin-right:-2em;
+			}
+		}
+		&.vk_outer-paddingLR-zero{
+			:is(.wp-block[data-align=full],.wp-block[data-align=wide] ){
+				margin-left:0;
+				margin-right:0;
+				width: 100%;
+				max-width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/lightning/issues/1050

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

G2にすると、編集画面の余白がなくなり、全幅サイズにしても編集画面では全幅にならなかったため、
G2用の block_editor_width.scss に必要な記載を G3用のblock_editor_width.scss からコピーして貼り付けました。



## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*
*
*

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*
*
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
