### PR TITLE
[ ヘッダーレイアウト ] ナビゲーション回り込みの時のロゴのリンクエリアが広い点を修正

### DIFF
--- a/_g3/assets/_scss/project/_site-header.scss
+++ b/_g3/assets/_scss/project/_site-header.scss
@@ -86,6 +86,10 @@ $logo_bottom_margin:1rem;
             img {
                 margin-left:0;
             }
+            a {
+		display: block; // 「ヘッダーレイアウト」の「ナビゲーション回り込み」の時のロゴのリンクエリアが広くならないための設定 
+                width: fit-content; // 同上
+            }
         }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -38,10 +38,11 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ Bug Fix ] Fixed the header layout where the logo link area is wider when the navigation wraps around.
 [ Specification Change ][ G3 ] Adjusting the preview mode for the VK Blocks Slider Block.
 
 v15.19.1
-[ Bug Fix ] Fixed the logo link area issue when using the header logo center layout(G3 Pro Unit).
+[ G3 ][ Bug Fix ] Fixed the logo link area issue when using the header logo center layout(G3 Pro Unit).
 
 v15.19.0
 [ Specification Change / Bug Fix ] Security update ( Update TGM & import from composer )


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1118 

## どういう変更をしたか？

* .site-header--layout--nav-float .site-header-logo a に「ヘッダーレイアウト」の「ナビゲーション回り込み」の時のロゴのリンクエリアが広くならないための設定をしました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 外観 > カスタマイズ > Lightning ヘッダー設定 > ヘッダーレイアウト「ナビゲーション回り込み」で保存。
* 上記設定保存後、ヘッダーロゴのリンクエリアがロゴの表示範囲になっていることを確認。
* ヘッダーレイアウト「ナビゲーション回り込み & 縦書き (β)」でも同様の現象となっていたが上記CSS変更で対応できていることを確認。
* ロゴ画像がない状態でも不具合がないことを確認。
* ブラウザはGoogle Chrome、Firefox、Safariで確認。
* ブラウザのモードは通常、シークレットモード、ゲストモードで確認。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 外観 > カスタマイズ > Lightning ヘッダー設定 > ヘッダーレイアウト「ナビゲーション回り込み」「ナビゲーション回り込み & 縦書き (β)」で保存してください。
* 上記設定保存後、ヘッダーロゴのリンクエリアがロゴの表示範囲になっていることを確認ください。
* ロゴ画像がない状態でも不具合がないことを確認ください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
