### PR TITLE
Fixed an issue where the WooCommerce CSS file failed to load on the edit screen when using WooCommerce.

### DIFF
--- a/_g3/plugin-support/woocommerce/functions-woo.php
+++ b/_g3/plugin-support/woocommerce/functions-woo.php
@@ -33,7 +33,7 @@ add_action( 'wp_enqueue_scripts', 'lightning_woo_css' );
  * @return void
  */
 function lightning_add_woocommerce_css_to_editor() {
-	add_editor_style( '/_g3/plugin-support/woocommerce/css/woo.css' );
+	add_editor_style( '/plugin-support/woocommerce/css/woo.css' );
 }
 add_action( 'after_setup_theme', 'lightning_add_woocommerce_css_to_editor' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,8 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
-[ Specification Change ] Update VK Components.
+[ G3 ][ Bug fix ] Fixed an issue where the WooCommerce CSS file failed to load on the edit screen when using WooCommerce.
+[ Other ] Update VK Component Posts.
 
 [ G2 ][ Design Bug Fix ] Fix 'a tag' style for global menu in WP 6.6.
 v15.26.2


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/lightning/issues/1178

## どういう変更をしたか？

WooCommerce用のファイル読み込みパス修正