### PR TITLE
[ G3 ][ Bug fix ] Fix profile image warning

### DIFF
--- a/_g3/inc/template-tags.php
+++ b/_g3/inc/template-tags.php
@@ -355,18 +355,22 @@ function lightning_get_entry_meta( $options = array() ) {
 				<span class="vcard author" itemprop="author">';
 
 				if ( $option['author_image'] ) {
-					$html .= '<span class="entry-meta-item-author-image">';
-
 					// VK Post Author Display の画像を取得.
-					$profile_image_id = get_the_author_meta( 'user_profile_image' );
-					if ( $profile_image_id ) {
-						$profile_image_src = wp_get_attachment_image_src( $profile_image_id, 'thumbnail' );
-						$html             .= '<img src="' . $profile_image_src[0] . '" alt="' . esc_attr( $author ) . '" />';
+					$profile_image_id                 = get_the_author_meta( 'user_profile_image' );
+					$vk_post_author_display_image_src = wp_get_attachment_image_src( $profile_image_id, 'thumbnail' );
+					// 画像がメディアライブラリ側で削除されたりもするため、 is_array で判定.
+					if ( is_array( $vk_post_author_display_image_src ) ) {
+						$profile_image = '<img src="' . $vk_post_author_display_image_src[0] . '" alt="' . esc_attr( $author ) . '" />';
 					} else {
-						$html .= get_avatar( get_the_author_meta( 'email' ), 30 );
+						// プロフィール画像がない場合は Gravatar.
+						$profile_image = get_avatar( get_the_author_meta( 'email' ), 30 );
 					}
 
-					$html .= '</span>';
+					if ( $profile_image ) {
+						$html .= '<span class="entry-meta-item-author-image">';
+						$html .= $profile_image;
+						$html .= '</span>';
+					}
 				}
 
 				if ( $option['author_name'] ) {

--- a/_g3/inc/template-tags.php
+++ b/_g3/inc/template-tags.php
@@ -356,10 +356,12 @@ function lightning_get_entry_meta( $options = array() ) {
 
 				if ( $option['author_image'] ) {
 					// VK Post Author Display の画像を取得.
-					$profile_image_id                 = get_the_author_meta( 'user_profile_image' );
-					$vk_post_author_display_image_src = wp_get_attachment_image_src( $profile_image_id, 'thumbnail' );
+					$profile_image_id = get_the_author_meta( 'user_profile_image' );
+					if ( $profile_image_id ) {
+						$vk_post_author_display_image_src = wp_get_attachment_image_src( $profile_image_id, 'thumbnail' );
+					}
 					// 画像がメディアライブラリ側で削除されたりもするため、 is_array で判定.
-					if ( is_array( $vk_post_author_display_image_src ) ) {
+					if ( isset( $vk_post_author_display_image_src ) && is_array( $vk_post_author_display_image_src ) ) {
 						$profile_image = '<img src="' . $vk_post_author_display_image_src[0] . '" alt="' . esc_attr( $author ) . '" />';
 					} else {
 						// プロフィール画像がない場合は Gravatar.

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,7 @@ https://www.vektor-inc.co.jp/inquiry/
 
 == Changelog ==
 
+[ G3 ][ Bug fix ] Fix profile image warning
 [ G2 ][ Specification Change ] Change load module priority
 
 v15.28.2


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/104402

投稿者の画像を取得する際に、まず VK Post Author Display で登録した画像があれば取得する。
しかしながら、画像のファイル自体を削除されてしまうと、画像データの配列が取得できずに、warning が発生する。

## どういう変更をしたか？

プロフィール画像を取得失敗した場合の処理を追加

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* master ブランチ
* G3 Pro Unit を有効化
* プラグイン VK Post Author Display をインストール・有効化
* ユーザー編集画面でプロフィール画像を登録
* プロフィール画像を登録したユーザーで記事を投稿
* 投稿詳細ページを表示 -> 普通に表示される
* プロフィール編集画面からメディアライブラリを開いて画像を削除（★プロフィール自体は保存しない）
* 投稿詳細ページでWarning が表示される
* このブランチに切り替え -> Warning が消える

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者に同じ

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
