### PR TITLE
[ G3 ][ デザイン不具合修正 ] アーカイブの最初に出る記事上の線が出なくなっていたのを修正しました

### DIFF
--- a/_g3/assets/_scss/overwrite/_vk-components.scss
+++ b/_g3/assets/_scss/overwrite/_vk-components.scss
@@ -63,7 +63,7 @@
             @media (min-width: $sm-min) {
                 padding: 1.5rem 0;
                 &:first-child {
-                    border-top: var(--vk-color-border-hr);
+                    border-top: 1px solid var(--vk-color-border-hr);
                 }
                 .media-img {
                     margin-right: 1.4rem;

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G3 ][ Design bug fix ] Fixed the missing top border on the first post in the archive view.
+
 v15.29.7
 [ G3 ][ Bug fix ] Fix LTG_G3_Slider call in index.php: add class_exists check and change render() to display_html().
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://discord.com/channels/1086176580675584011/1380368043129049200/1380368043129049200

## どういう変更をしたか？

border-topに太さやスタイルの指定がないため、線が表示されていませんでしたのでそれを修正しました。
お一人で大丈夫かと思います。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2025-06-06 16 49 46](https://github.com/user-attachments/assets/93299f32-fe73-4e7d-88f4-6b15807185b6)

#### 変更後 After
![スクリーンショット 2025-06-06 16 51 12](https://github.com/user-attachments/assets/4daa9649-5d32-4279-8218-f218d3e3b3d9)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？ → CSSのみなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

このプルリクを npm run build した後、Lightining G3で投稿やカスタム投稿タイプのアーカイブを開き、最初に出る記事上の線が出なくなっているのを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
