### PR TITLE
【保留】[ G3 ][ デザインバグ修正 ] ネストされた alignwide ブロックが全幅カバー内の親ブロックからオーバーフローする問題を修正しました。

### DIFF
--- a/_g3/assets/_scss/block/_block_width.scss
+++ b/_g3/assets/_scss/block/_block_width.scss
@@ -66,6 +66,24 @@ body :where(.alignfull,.alignwide):where(:not(.vk_outer-paddingLR-zero)) .is-lay
 	& > .alignwide {
 		margin-left: calc( ( 100% - var(--vk-width-full) ) / 4 ) !important;
 		margin-right: calc( ( 100% - var(--vk-width-full) ) / 4 ) !important;
+		// ネストされた .alignwide が親のはみ出しを起こさないように制御
+		& > .alignwide {
+			width: 100%;
+			max-width: 100%;
+			// 親の .alignwide に !important がついているため、こちらも !important を付けて上書き
+			margin-left: 0 !important; 
+			margin-right: 0 !important;
+		}
+	}
+	& > .alignfull {
+		margin-left: calc(50% - 50vw);
+		margin-right: calc(50% - 50vw);
+		// ネストされた .alignwide が左によらないように中央寄席せ制御
+		& > .alignwide {
+			// 親の .alignwide に !important がついているため、こちらも !important を付けて上書き
+			margin-left: auto !important; 
+			margin-right: auto !important;
+		}
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G3 ][ Design bug fix ] Fix an issue where nested alignwide blocks overflow from their parent blocks in full-width covers.
 [ G3 ][ Other ] CSS Optimize ( Resolve Sass mixed-decls warnings )
 
 v15.29.9


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

ことりさんからレイアウト崩れのご報告をいただきましたので、修正しました。

> カバー > グループ > カラムブロックで表現している箇所で、カラムブロックの幅を「広幅」「全幅」にした際に左に寄ってしまうのです。

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->

**ネストした幅広ブロックのはみ出し防止**
   - 幅広ブロック内の幅広ブロックに対して、`width: 100%`と`margin: 0`を設定

**全幅ブロック内の全幅ブロックの制御を追加**
   - 全幅ブロック内の全幅ブロックに対して、正しいマージン（`calc(50% - 50vw)`）を設定
   - 全幅ブロック内の幅広ブロックに対して、左によらないように中央寄席せ制御


### スクリーンショットまたは動画

#### 変更前 Before

#### 変更後 After


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

*
*
*

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

*
*
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
