### PR TITLE
[ G2 ][ Bug fix ] Fix an issue where Bootstrap CSS is not loaded in the iframe of the block editor on the edit screen.

### DIFF
--- a/_g2/library/bootstrap-4/css/bootstrap.min.css
+++ b/_g2/library/bootstrap-4/css/bootstrap.min.css
@@ -1,4 +1,4 @@
-/*!
+.wp-block-group{--for-block-editor-css-activate:"don't delete"}/*!
 * Bootstrap v4.6.2 (https://getbootstrap.com/)	* Bootstrap v4.6.2 (https://getbootstrap.com/)
 * Copyright 2011-2020 The Bootstrap Authors	* Copyright 2011-2022 The Bootstrap Authors
 * Copyright 2011-2020 Twitter, Inc.	* Copyright 2011-2022 Twitter, Inc.

--- a/_g2/library/bootstrap-4/scss/bootstrap.scss
+++ b/_g2/library/bootstrap-4/scss/bootstrap.scss
@@ -1,3 +1,4 @@
+.wp-block-group{--for-block-editor-css-activate:"don't delete"}
 /*!
 * Bootstrap v4.6.2 (https://getbootstrap.com/)	* Bootstrap v4.6.2 (https://getbootstrap.com/)
 * Copyright 2011-2020 The Bootstrap Authors	* Copyright 2011-2022 The Bootstrap Authors

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G2 ][ Bug fix ] Fix an issue where Bootstrap CSS is not loaded in the iframe of the block editor on the edit screen.
+
 v15.30.0
 [ G3 ][ Specification Change ] Change CSS file structure
 


### PR DESCRIPTION
https://github.com/vektor-inc/lightning-pro/pull/304/files