### PR TITLE
[ 不具合修正 ] 同じサイト内の記事どうしで埋め込むとブログカードの処理が無限ループになりメモリオーバーでエラーになる不具合を修正

### DIFF
--- a/_g3/inc/vk-wp-oembed-blog-card/package/class-vk-wp-oembed-blog-card.php
+++ b/_g3/inc/vk-wp-oembed-blog-card/package/class-vk-wp-oembed-blog-card.php
@@ -121,7 +121,22 @@ if ( ! class_exists( 'VK_WP_Oembed_Blog_Card' ) ) {
 			$blog_card_data['url']         = get_permalink( $post_id );
 			$blog_card_data['title']       = get_the_title( $post_id );
 			$blog_card_data['thumbnail']   = get_the_post_thumbnail_url( $post_id, 'large' );
-			$blog_card_data['description'] = get_the_excerpt( $post_id );
+
+			// 抜粋情報の取得 ////////
+			// Get post excerpt ////
+			// get_the_excerpt() は記事AとBが互いに埋め込んだ場合に無限ループになるので使わない。
+			// get_the_excerpt() is not used to avoid infinite loops when posts A and B embed each other.
+			$post    = get_post( $post_id );
+			$excerpt = $post->post_excerpt;
+			// 抜粋が空の場合は本文から取得
+			if ( empty( $excerpt ) && ! empty( $post->post_content ) ) {
+				$content        = wp_strip_all_tags( strip_shortcodes( $post->post_content ) );
+				$content        = preg_replace( '/https?:\/\/[^\s]+/', '', $content );
+				$excerpt_length = apply_filters( 'vk_wp_oembed_blog_card_excerpt_length', 240 );
+				$excerpt        = wp_trim_words( $content, $excerpt_length, '...' );
+			}
+
+			$blog_card_data['description'] = $excerpt;
 			$blog_card_data['favicon']     = get_site_icon_url( 32 );
 			$blog_card_data['site_name']   = get_bloginfo( 'name', 'display' );
 			$blog_card_data['domain']      = home_url();

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G3 ][ Bug fix ] Fix an issue where embedding posts from the same site into each other causes the blog card process to enter an infinite loop, resulting in a memory overflow error.
 [ G2 ][ Bug fix ] Fix an issue where Bootstrap CSS is not loaded in the iframe of the block editor on the edit screen.
 
 v15.30.0


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/lightning/issues/1258

## どういう変更をしたか？

get_the_excerpt() 以外の方法で抜粋を取得するように変更

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 記事Aに記事BのURLを埋め込み
2. 記事Bに記事AのURLを埋め込み
3. ブログカードの処理が無限ループでメモリオーバーでエラーになる
4. このブランチ版に切り替え
5. 記事A，記事Bともに正常に表示されるようになる事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
