### PR TITLE
[ その他 ] readme.txt に Stable tag を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Lightning WordPress theme, Copyright (C) 2015-2026 Vektor,Inc.
 Lightning WordPress theme is licensed under the GPL.
 Tested up to: 6.9
+Stable tag: 15.34.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- readme.txt に `Stable tag: 15.34.1` を追加
- `Stable tag` が欠落していると WordPress.org のビルドシステムが zip を正しく再生成せず、古いバージョンが配信され続ける問題への対応

Related: vektor-inc/multi-repo-tasks#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 安定版タグを 15.34.1 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->