### PR TITLE
[ G2/G3 ][ 不具合修正 ] Lightning Pro で覚えた正スペル `header_scroll` を Lightning に書いてもヘッダー固定が制御できなかった非対称を修正

### DIFF
--- a/inc/functions-compatible.php
+++ b/inc/functions-compatible.php
@@ -129,3 +129,44 @@ function lightning_g3_site_body_append_spell_miss_compatibility() {
 	do_action( 'lightning_site_body_apepend', 'lightning_site_body_apepend' );
 }
 add_action( 'lightning_site_body_append', 'lightning_g3_site_body_append_spell_miss_compatibility' );
+
+/*
+  Backward compatibility for header scroll option key
+  ※ Lightning（G2/G3）の内部キーはタイポの `header_scrool` のままになっている。
+  ※ Lightning Pro 側では `header_scroll` にリネーム済みのため、Pro で覚えた正スペル
+  ※ `header_scroll` を Lightning に書いても効かない非対称が存在していた。
+  ※ そこで `lightning_localize_options` フィルタの最終段で新キー `header_scroll` の値を
+  ※ 旧キー `header_scrool` にコピーし、ユーザーがどちらのスペルでも書けるようにする。
+  ※ Pro #358 と同じ目的だが、Lightning では同期方向が逆（新キー → 旧キー）となる点に注意。
+/*-------------------------------------------*/
+add_filter( 'lightning_localize_options', 'lightning_header_scrool_typo_compatible', PHP_INT_MAX, 1 );
+/**
+ * Sync the correctly-spelled "header_scroll" option key into the legacy "header_scrool" key.
+ *
+ * Lightning の内部キーはタイポの `header_scrool` が正規キーとして扱われており、
+ * JS 側（lightning.min.js）もこのキー名を参照している。一方、ユーザーが Pro 側で
+ * リネーム後の正スペル `header_scroll` を覚えている場合に Lightning でも同じ書き方
+ * ができるよう、新キー `header_scroll` が設定されていれば旧キー `header_scrool` に
+ * その値をコピーする。フィルタチェーンの最終段で実行されるよう priority を
+ * PHP_INT_MAX に設定している。
+ *
+ * 正規キーは内部的には `header_scrool`（タイポ）、`header_scroll` は外部公開向けの
+ * 正スペルキーとして扱う。両方のキーが同時に指定された場合は、ユーザーが意図して
+ * 書いた可能性が高い「新キー（正スペル）」を後勝ちとする。
+ *
+ * @param array $options Localized options passed to the lightning-js script.
+ * @return array Modified options with header_scrool synchronized from header_scroll when applicable.
+ */
+function lightning_header_scrool_typo_compatible( $options ) {
+	// 配列でない場合はそのまま返す（防御的チェック）。
+	if ( ! is_array( $options ) ) {
+		return $options;
+	}
+	// 新キー（正スペル）`header_scroll` が指定されている場合のみ、
+	// 旧キー（内部レガシー）`header_scrool` にその値をコピーする。
+	// 旧キー単独で指定されている場合は従来通り旧キーがそのまま使われるため、何もしない。
+	if ( array_key_exists( 'header_scroll', $options ) ) {
+		$options['header_scrool'] = $options['header_scroll'];
+	}
+	return $options;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G3/G2 ][ Bug fix ] Added backward compatibility hook to accept `header_scroll` (correct spelling) in addition to the legacy `header_scrool` key for the `lightning_localize_options` filter, so user code using either spelling works consistently with Lightning Pro.
+
 v15.35.1
 [ G3 ][ Bug fix ] Restore the native dropdown arrow on select element that disappeared after `appearance: none` was applied for iOS form rendering (#1322)
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
-[ G3/G2 ][ Bug fix ] Added backward compatibility hook to accept `header_scroll` (correct spelling) in addition to the legacy `header_scrool` key for the `lightning_localize_options` filter, so user code using either spelling works consistently with Lightning Pro.
+[ G2/G3 ][ Bug Fix ] Added backward compatibility hook to accept `header_scroll` (correct spelling) in addition to the legacy `header_scrool` key for the `lightning_localize_options` filter, so user code using either spelling works consistently with Lightning Pro.
 
 v15.35.1
 [ G3 ][ Bug fix ] Restore the native dropdown arrow on select element that disappeared after `appearance: none` was applied for iOS form rendering (#1322)

--- a/tests/test-lightning_header_scrool_typo_compatible.php
+++ b/tests/test-lightning_header_scrool_typo_compatible.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Lightning_Header_Scrool_Typo_Compatible_Test
+ *
+ * `lightning_header_scrool_typo_compatible()` のテスト。
+ * 新キー（正スペル）`header_scroll` を旧キー（内部レガシー）`header_scrool` に
+ * コピーする後方互換 hook の挙動を検証する。
+ *
+ * @package vektor-inc/lightning
+ */
+
+/**
+ * Class Lightning_Header_Scrool_Typo_Compatible_Test
+ */
+class Lightning_Header_Scrool_Typo_Compatible_Test extends WP_UnitTestCase {
+
+	/**
+	 * lightning_header_scrool_typo_compatible() の動作テスト。
+	 *
+	 * 各ケースで `lightning_localize_options` フィルタへの入力（$options）と
+	 * 期待される出力（$expected）を配列で定義し、ループで一括検証する。
+	 */
+	public function test_lightning_header_scrool_typo_compatible() {
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '新キー header_scroll = false を指定した場合、旧キー header_scrool にも false がコピーされる',
+				'options'             => array(
+					'header_scroll' => false,
+				),
+				'expected'            => array(
+					'header_scroll' => false,
+					'header_scrool' => false,
+				),
+			),
+			array(
+				'test_condition_name' => '新キー header_scroll = true を指定した場合、旧キー header_scrool にも true がコピーされる',
+				'options'             => array(
+					'header_scroll' => true,
+				),
+				'expected'            => array(
+					'header_scroll' => true,
+					'header_scrool' => true,
+				),
+			),
+			array(
+				'test_condition_name' => '新キー header_scroll が無い場合、旧キー header_scrool はそのまま改変されない',
+				'options'             => array(
+					'header_scrool' => true,
+				),
+				'expected'            => array(
+					'header_scrool' => true,
+				),
+			),
+			array(
+				'test_condition_name' => '旧キーと新キーの両方が指定された場合、新キー（正スペル）の値が後勝ちで旧キーに上書きされる',
+				'options'             => array(
+					'header_scrool' => true,
+					'header_scroll' => false,
+				),
+				'expected'            => array(
+					'header_scrool' => false,
+					'header_scroll' => false,
+				),
+			),
+			array(
+				'test_condition_name' => '空配列を渡した場合、空配列のまま返る（新キーが無いので何もしない）',
+				'options'             => array(),
+				'expected'            => array(),
+			),
+			array(
+				'test_condition_name' => '非配列（null）を渡した場合、防御的チェックでそのまま返る',
+				'options'             => null,
+				'expected'            => null,
+			),
+			array(
+				'test_condition_name' => '非配列（文字列）を渡した場合、防御的チェックでそのまま返る',
+				'options'             => 'invalid_string',
+				'expected'            => 'invalid_string',
+			),
+			array(
+				'test_condition_name' => 'issue #1326 シナリオ: design-skin が priority 10 で旧キー true を入れた後、ユーザーが priority 11 で新キー false を入れた場合、最終的に旧キーが false に上書きされる',
+				// この最終 options は「design-skin の priority 10（旧キー true）→ ユーザーフィルタ priority 11（新キー false）」が
+				// 順に適用された後の状態を再現したもの。compat hook は priority PHP_INT_MAX で実行されるので
+				// このタイミングでは両キーが共存している。
+				'options'             => array(
+					'header_scrool' => true,
+					'header_scroll' => false,
+				),
+				'expected'            => array(
+					'header_scrool' => false,
+					'header_scroll' => false,
+				),
+			),
+		);
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'lightning_header_scrool_typo_compatible()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		foreach ( $test_cases as $case ) {
+			// 対象関数を直接呼び出して結果を取得する。
+			$actual = lightning_header_scrool_typo_compatible( $case['options'] );
+
+			// 期待値と一致するかを検証する。
+			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
+		}
+	}
+
+	/**
+	 * フィルタチェーン全体での挙動を検証する統合テスト。
+	 *
+	 * `lightning_localize_options` フィルタを実際に発火させ、
+	 * 後方互換 hook が priority PHP_INT_MAX で最終段に動作することを確認する。
+	 * issue #1326 のシナリオ（design-skin が priority 10 で旧キー true、
+	 * ユーザーが priority 11 で新キー false）を再現する。
+	 */
+	public function test_lightning_header_scrool_typo_compatible_via_filter_chain() {
+
+		// design-skin 相当: priority 10 で旧キー header_scrool に true をセットする。
+		$design_skin_filter = function ( $options ) {
+			$options['header_scrool'] = true;
+			return $options;
+		};
+		add_filter( 'lightning_localize_options', $design_skin_filter, 10, 1 );
+
+		// ユーザー追加コード相当: priority 11 で新キー header_scroll に false をセットする。
+		$user_filter = function ( $options ) {
+			$options['header_scroll'] = false;
+			return $options;
+		};
+		add_filter( 'lightning_localize_options', $user_filter, 11, 1 );
+
+		// 実際のフィルタを発火させる。
+		$result = apply_filters( 'lightning_localize_options', array() );
+
+		// 後方互換 hook により、最終的に旧キー header_scrool が false に上書きされていることを確認する。
+		$this->assertArrayHasKey( 'header_scrool', $result, 'header_scrool キーが結果に含まれること' );
+		$this->assertFalse( $result['header_scrool'], 'issue #1326 シナリオで旧キー header_scrool が新キー header_scroll の値 false で後勝ち上書きされる' );
+		$this->assertFalse( $result['header_scroll'], '新キー header_scroll は false のまま維持される' );
+
+		// 後処理: 追加したフィルタを削除する（他テストへの副作用防止）。
+		remove_filter( 'lightning_localize_options', $design_skin_filter, 10 );
+		remove_filter( 'lightning_localize_options', $user_filter, 11 );
+	}
+}

--- a/tests/test-lightning_header_scrool_typo_compatible.php
+++ b/tests/test-lightning_header_scrool_typo_compatible.php
@@ -132,16 +132,19 @@ class Lightning_Header_Scrool_Typo_Compatible_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'lightning_localize_options', $user_filter, 11, 1 );
 
-		// 実際のフィルタを発火させる。
-		$result = apply_filters( 'lightning_localize_options', array() );
+		try {
+			// 実際のフィルタを発火させる。
+			$result = apply_filters( 'lightning_localize_options', array() );
 
-		// 後方互換 hook により、最終的に旧キー header_scrool が false に上書きされていることを確認する。
-		$this->assertArrayHasKey( 'header_scrool', $result, 'header_scrool キーが結果に含まれること' );
-		$this->assertFalse( $result['header_scrool'], 'issue #1326 シナリオで旧キー header_scrool が新キー header_scroll の値 false で後勝ち上書きされる' );
-		$this->assertFalse( $result['header_scroll'], '新キー header_scroll は false のまま維持される' );
-
-		// 後処理: 追加したフィルタを削除する（他テストへの副作用防止）。
-		remove_filter( 'lightning_localize_options', $design_skin_filter, 10 );
-		remove_filter( 'lightning_localize_options', $user_filter, 11 );
+			// 後方互換 hook により、最終的に旧キー header_scrool が false に上書きされていることを確認する。
+			$this->assertArrayHasKey( 'header_scrool', $result, 'header_scrool キーが結果に含まれること' );
+			$this->assertFalse( $result['header_scrool'], 'issue #1326 シナリオで旧キー header_scrool が新キー header_scroll の値 false で後勝ち上書きされる' );
+			$this->assertFalse( $result['header_scroll'], '新キー header_scroll は false のまま維持される' );
+		} finally {
+			// 後処理: 追加したフィルタを削除する（他テストへの副作用防止）。
+			// アサーション失敗で例外が出ても remove_filter を確実に実行する。
+			remove_filter( 'lightning_localize_options', $design_skin_filter, 10 );
+			remove_filter( 'lightning_localize_options', $user_filter, 11 );
+		}
 	}
 }


### PR DESCRIPTION
## 概要

Lightning（G2/G3）の `lightning_localize_options` フィルタの内部キーはタイポの `header_scrool` のまま残っており、JS（`lightning.min.js`）も `_g2/design-skin/origin2/origin2.php:81` も `_g3/functions.php:285` も全て `header_scrool` を参照していた。一方、Lightning Pro は過去に `header_scroll`（正スペル）にリネーム済みで、Pro PR #358 で旧キー → 新キー方向の後方互換 hook を追加していたため、**「Pro で覚えた正スペル `header_scroll` を Lightning に書いても効かない」非対称**が発生していた。

この非対称を解消するため、Lightning では JS / PHP の内部参照を `header_scrool`（タイポ）のまま据え置き、`lightning_localize_options` フィルタの最終段（優先度 `PHP_INT_MAX`）で **新キー `header_scroll` の値を旧キー `header_scrool` にコピー** する後方互換 hook を追加。これにより、ユーザーは Pro と同じ正スペル `header_scroll` でも従来通り旧スペル `header_scrool` でもどちらでも書けるようになる。

Pro PR #358 は「旧キー → 新キー」、Lightning は「新キー → 旧キー」と**同期方向が逆**になる点が本 PR のキモ。理由は JS が参照しているキー名が Pro と Lightning で異なるため。

Fixes #1326

## 主要な実装ポイント

- **関数名**: `lightning_header_scrool_typo_compatible()`（Pro 側 `lightning_pro_header_scrool_typo_compatible` とプレフィックスを揃えた命名）
- **priority**: `PHP_INT_MAX`（design-skin の priority 10 やユーザー独自フィルタが全て走った後の最終段で同期）
- **後勝ち**: 旧キー・新キーの両方が指定された場合は **新キー（正スペル）の値が後勝ち** で旧キーに上書きされる（ユーザーが意図的に正スペルで書いた可能性が高いため。植草レビュー意見）
- **防御的チェック**: 非配列入力（null / 文字列）はそのまま返す（Pro #358 と同じ）
- **PHPDoc**: 「正規キーは内部的には `header_scrool`（タイポ）、`header_scroll` は外部公開向け正スペルキー」と明記

## 確認手順

### 前提条件

- Lightning テーマを有効化（G2 / G3 どちらでも可。design-skin に `Origin II` を選択すると `header_scrool` がデフォルトで `true` になりヘッダーが固定される）
- 表示ページに十分な高さのコンテンツがあり、スクロールできる状態にしておく

### 手順

#### Before（修正前の再現手順）

1. テーマの `functions.php` または子テーマに以下のカスタマイズコードを追加する（**正スペル `header_scroll`** で書いた場合）

   ```php
   function my_lightning_global_nav_fix( $options ) {
       $options['header_scroll'] = false;
       return $options;
   }
   add_filter( 'lightning_localize_options', 'my_lightning_global_nav_fix', 11, 1 );
   ```

2. フロントページを開いてスクロールする
   → ✗ ヘッダーが固定されたままで、解除されない（Lightning 内部は `header_scrool`（タイポ）を参照しているため、正スペルで書いても効かない）

#### After（修正後）

1. 上記と同じ正スペル `header_scroll` のコードのまま、フロントページを開いてスクロールする
   → ✓ ヘッダー固定が解除されている（新キーの値が旧キー `header_scrool` に反映され、JS 側がそれを読み取って固定を解除する）

2. カスタマイズコードを以下の旧スペル `header_scrool` に書き換えて再度スクロールする

   ```php
   function my_lightning_global_nav_fix( $options ) {
       $options['header_scrool'] = false;
       return $options;
   }
   add_filter( 'lightning_localize_options', 'my_lightning_global_nav_fix', 11, 1 );
   ```

   → ✓ 旧スペルでも従来通りヘッダー固定が解除される（既存挙動を維持・リグレッションなし）

3. カスタマイズコードを全て削除してフロントページをリロードしてスクロールする
   → ✓ Origin II のデフォルト挙動どおりヘッダーが固定される（デグレなし）

### PHPUnit

`tests/test-lightning_header_scrool_typo_compatible.php` に以下のテストを追加済み。`npm run phpunit:root` で実行可能。

#### `test_lightning_header_scrool_typo_compatible`（ループ 8 ケース）

1. 新キー `header_scroll = false` → 旧キー `header_scrool = false`（正常系）
2. 新キー `header_scroll = true` → 旧キー `header_scrool = true`（正常系）
3. 新キーなし → 旧キーそのまま（境界値・無改変）
4. 旧キー・新キー両方 → 新キー後勝ち
5. 空配列 → そのまま
6. 非配列（null） → そのまま（防御的チェック）
7. 非配列（文字列） → そのまま（防御的チェック）
8. issue #1326 シナリオ再現（priority 10 で旧キー `true`、priority 11 で新キー `false` → 最終的に旧キーが `false` で上書き）

#### `test_lightning_header_scrool_typo_compatible_via_filter_chain`（統合テスト 1 ケース）

- `apply_filters( 'lightning_localize_options', ... )` を実際に発火させ、後方互換 hook が priority `PHP_INT_MAX` で最終段に動作することを確認

#### 実行結果（手元）

- `phpunit.root.xml`: 5 tests / 31 assertions OK
- `phpunit.g2.xml`: 23 tests / 149 assertions OK
- `phpunit.g3.xml`: 22 tests / 139 assertions OK

## ビルドについて

JS には触っていない（`lightning.min.js` は従来通り `lightningOpt.header_scrool` を参照する側）。ビルド不要。

## 関連

- セキュリティレビュー（安藤） PASS 済み: https://github.com/vektor-inc/lightning/issues/1326#issuecomment-4417459928
- Pro 側の対応 PR（同期方向は逆）: https://github.com/vektor-inc/lightning-pro/pull/358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- テーマオプション機能の後方互換性を向上させました。既存のカスタマイズコードが引き続き正常に動作するようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->