### PR TITLE
[ G2/G3 ][ Bug Fix ] header_scroll_func の addEventListener/removeEventListener の capture フラグ不一致を修正 (#1331)

### DIFF
--- a/_g2/assets/_js/_master.js
+++ b/_g2/assets/_js/_master.js
@@ -36,7 +36,7 @@
             }
             body_class_lock = true
             body_class_timer = setTimeout(()=>{
-                window.addEventListener('scroll', header_scroll_func, true)
+                window.addEventListener('scroll', header_scroll_func, false)
                 body_class_lock = false
             }, 2000);
         }

--- a/_g3/assets/_js/_master.js
+++ b/_g3/assets/_js/_master.js
@@ -74,7 +74,7 @@
             }
             body_class_lock = true
             body_class_timer = setTimeout(()=>{
-                window.addEventListener('scroll', header_scroll_func, true)
+                window.addEventListener('scroll', header_scroll_func, false)
                 body_class_lock = false
             }, 2000);
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G2/G3 ][ Bug Fix ] Fix scroll listener being left attached after in-page anchor clicks because `addEventListener` re-registered `header_scroll_func` with `capture: true` while `removeEventListener` used `capture: false`, causing the `header_scrolled` class to behave inconsistently
 [ G2/G3 ][ Bug Fix ] Added backward compatibility hook to keep user code using the legacy `header_scrool` key working after renaming the internal option key from `header_scrool` to `header_scroll` for the `lightning_localize_options` filter. Note: JavaScript code that directly references `lightningOpt.header_scrool` will need to be updated to `lightningOpt.header_scroll`.
 
 v15.35.1


### PR DESCRIPTION
## 概要

関連 issue: #1331

`_g2/assets/_js/_master.js` および `_g3/assets/_js/_master.js` の `remove_header` 関数内で、`header_scroll_func` を再登録する `addEventListener` の第3引数（capture フラグ）が `true` になっており、削除側の `removeEventListener`（capture: false）と不一致でした。

ブラウザの EventTarget 仕様上、addEventListener / removeEventListener は capture フラグが揃っていないと同一リスナーとして扱わないため、`removeEventListener` が無音で失敗し、scroll リスナーが意図せず残り続ける既存バグになっていました。結果としてページ内リンククリック後に `header_scrolled` クラスの付与・解除挙動が不安定になります。

両ファイルとも `capture: false` に揃えることで、addEventListener / removeEventListener が同一リスナーをターゲットにするように修正しました。

## 変更内容

- `_g2/assets/_js/_master.js`: `remove_header` 内の `addEventListener('scroll', header_scroll_func, true)` を `false` に変更
- `_g3/assets/_js/_master.js`: `remove_header` 内の `addEventListener('scroll', header_scroll_func, true)` を `false` に変更
- `readme.txt`: Changelog に `[ G2/G3 ][ Bug Fix ]` エントリを追加

なお、`_g2/assets/_js/_master.js` L58 の初期登録（`window.addEventListener('scroll', header_scroll_func, true)`）も capture: true ですが、本 issue のスコープ外のため本 PR では変更していません。別 issue で検討予定です。

## 確認手順

### 前提条件
- Lightning G3 もしくは G2 デザインを有効化
- カスタマイザー > ヘッダー設定で「スクロール時にヘッダーをコンパクトにする（header_scroll）」相当の設定を有効化
- 公開ページに「#で始まるページ内リンク」（例: `<a href=\"#section-1\">`）と、ある程度スクロールが必要な縦長コンテンツを配置

### 手順

#### Before（修正前の再現手順）
1. 公開ページを開きスクロールして `body` に `header_scrolled` クラスが付くことを確認
2. ページ内リンク（`#xxx`）をクリック
3. クリック直後にもう一度スクロールしてみる
   → ✗ `remove_header` が走った後も scroll リスナーが二重登録された状態になり、`body_class_lock` 解除後に `header_scrolled` クラスの付与・解除タイミングが不安定（リスナーが残ったままになる）

#### After（修正後）
1. 公開ページを開きスクロールして `body` に `header_scrolled` クラスが付くことを確認
   → OK: スクロール量 160px 超で `header_scrolled` が付与される
2. ページ内リンク（`#xxx`）をクリック
   → OK: `header_scrolled` クラスが除去され、ロック中（2秒）はクラスが付かない
3. クリック直後にもう一度スクロールしてみる
   → OK: ロック中はクラスが付かず、2秒経過後の通常スクロールで再び `header_scrolled` が付く
4. DevTools の Event Listeners タブで `window` の `scroll` を確認
   → OK: クリック → 2秒経過後の再登録後も scroll リスナーは 1 件のまま（重複登録されていない）
5. G2 / G3 の両方で 1〜4 を確認
   → OK: 両デザインで同じ挙動

### デグレ確認
- スクロール時のヘッダー縮小機能（`header_scrolled` クラスに依存するスタイル）が従来どおり動作することを確認
- ページ内リンククリック以外の通常スクロール／リサイズで挙動が変わらないことを確認

## スクリーンショット

純粋な JS のイベントリスナー登録ロジックの修正で、見た目の変更を伴わないため省略。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* スクロール時のヘッダー動作における不安定性を修正しました。ページ内リンククリック後、スクロール状態管理がより正確に機能するようになり、ヘッダーの表示/非表示の切り替え動作がより一貫性を持つようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1332)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->