### PR TITLE
[ G3 ][ その他 ] bbPress 関数の未使用変数 $users を削除

### DIFF
--- a/_g3/plugin-support/bbpress/functions-bbpress.php
+++ b/_g3/plugin-support/bbpress/functions-bbpress.php
@@ -81,7 +81,6 @@ function lightning_bbp_breadcrumb_array( $array ) {
 
 		global $wp_query;
 		if ( isset( $wp_query->query['bbp_user'] ) && ! empty( $wp_query->query['bbp_user'] ) ) {
-			$users = get_users( array( 'search' => $wp_query->query['bbp_user'] ) );
 			$array[] = array(
 				'name'  => lightning_get_the_bbp_display_name(),
 				'id'    => '',


### PR DESCRIPTION
## 概要

`_g3/plugin-support/bbpress/functions-bbpress.php` の `lightning_bbp_breadcrumb_array()` 内で、`get_users()` の戻り値を `$users` 変数に代入しているが、その後の処理で `$users` が一切使われておらず未使用のままだった。当該行を削除する。

Closes #1275

## 変更内容

- `lightning_bbp_breadcrumb_array()` 内の未使用変数 `$users = get_users( ... );` を削除（_g3/plugin-support/bbpress/functions-bbpress.php:84）

## changelog

エンドユーザーに影響のない内部リファクタリング（未使用変数の削除）のため、changelog への追記は省略。

## 確認手順

### 前提条件

- bbPress プラグインを有効化
- Lightning G3 を有効化

### 手順

1. bbPress のユーザープロフィールページ（例: `/forums/users/<username>/`）にアクセスする
2. パンくずリストの表示を確認する
   → ✓ 該当ユーザーの表示名がパンくずに表示される（修正前と同じ表示）
3. デバッグログを有効にした状態でアクセスしても PHP の Notice / Warning が出ないことを確認する
   → ✓ エラーが出ない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * bbPresページの読み込み処理を最適化しました。不要なユーザーデータの照合を削除し、表示名取得をより効率的に改善しています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1338)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->