### PR TITLE
[ G3 ][ Dev Environment ] vk-wp-oembed-blog-card の PHPUnit テストが外部 OGP 取得状況に依存して flaky になる不具合を修正

### DIFF
--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -21,8 +21,57 @@
 class BlogCardTest extends WP_UnitTestCase {
 
 	/**
+	 * テスト前処理: vektor-inc.co.jp への HTTP リクエストを失敗固定するモックを登録
+	 *
+	 * CI 環境から外部 OGP サイトへ接続できるかどうかで `oembed_html` / `maybe_make_link`
+	 * の出力が変動し、テストが flaky 化していた。
+	 * `pre_http_request` で `WP_Error` を返すことで、常に「OGP 取得失敗時の
+	 * URL のみフォールバック表示」ケースを検証できるようにする。
+	 *
+	 * 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed discovery）にも
+	 * 同じモックを効かせる必要があるため、`set_up` 段階でフィルタを登録している。
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10, 3 );
+	}
+
+	/**
+	 * テスト後処理: モック用フィルタを解除する
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * vektor-inc.co.jp 宛ての HTTP リクエストを失敗として固定するためのモック
+	 *
+	 * `pre_http_request` フィルタは false 以外を返すと実際の HTTP 通信を行わずに
+	 * その値を結果として使う仕様。
+	 * vektor-inc.co.jp ドメインのリクエストのみ `WP_Error` を返して失敗扱いとし、
+	 * YouTube oEmbed や内部リンクなどはそのまま通すために `$pre` を返す。
+	 *
+	 * @param false|array|WP_Error $pre  既存の pre_http_request の戻り値（通常 false）
+	 * @param array                $args HTTP リクエストの引数
+	 * @param string               $url  リクエスト先 URL
+	 * @return false|array|WP_Error vektor-inc.co.jp なら WP_Error、それ以外は $pre をそのまま返す
+	 */
+	public function mock_http_fail( $pre, $args, $url ) {
+		// vektor-inc.co.jp 宛てのリクエストのみ失敗扱いに固定する
+		if ( false !== strpos( $url, 'vektor-inc.co.jp' ) ) {
+			return new \WP_Error( 'http_request_failed', 'mocked' );
+		}
+		// それ以外のドメインは通常通り処理させる
+		return $pre;
+	}
+
+	/**
 	 * oembed_html 内部リンク、WordPressで作られたサイトのテスト
 	 * cache は 管理画面URLを貼り付けた時に自動で変換される文字列
+	 *
+	 * vektor-inc.co.jp の OGP 取得は `mock_http_fail` で失敗固定しているため、
+	 * 期待値（`correct`）も実出力もフォールバック HTML（URL のみのリンク）となる。
 	 */
 	function test_vk_get_post_data_blog_card() {
 		// Create test post

--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -21,6 +21,19 @@
 class BlogCardTest extends WP_UnitTestCase {
 
 	/**
+	 * `the_content` に対する `wpautop` フィルタが set_up 時点で
+	 * 登録されていたかどうかを記憶するフラグ。
+	 *
+	 * 各テストは検証時に `remove_filter( 'the_content', 'wpautop' )` →
+	 * 末尾で `add_filter( 'the_content', 'wpautop' )` を呼ぶ運用だが、
+	 * アサーション失敗で途中 abort した場合に復元が漏れ、後続テストに
+	 * 影響することを防ぐため tear_down で確実に復元する。
+	 *
+	 * @var bool
+	 */
+	private $had_wpautop = false;
+
+	/**
 	 * テスト前処理: vektor-inc.co.jp への HTTP リクエストを失敗固定するモックを登録
 	 *
 	 * CI 環境から外部 OGP サイトへ接続できるかどうかで `oembed_html` / `maybe_make_link`
@@ -30,16 +43,30 @@ class BlogCardTest extends WP_UnitTestCase {
 	 *
 	 * 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed discovery）にも
 	 * 同じモックを効かせる必要があるため、`set_up` 段階でフィルタを登録している。
+	 *
+	 * あわせて、`the_content` に対する `wpautop` フィルタの登録状態を記憶しておく。
+	 * 各テストは検証ロジックの直前で `remove_filter` し、末尾で `add_filter` で
+	 * 戻す運用だが、テストが途中で失敗した場合は復元が漏れる。
+	 * tear_down 側で「元々あったのに今ない」場合のみ復元することで、
+	 * 後続テストへの汚染を防ぐ。
 	 */
 	public function set_up() {
 		parent::set_up();
 		add_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10, 3 );
+		$this->had_wpautop = false !== has_filter( 'the_content', 'wpautop' );
 	}
 
 	/**
-	 * テスト後処理: モック用フィルタを解除する
+	 * テスト後処理: モック用フィルタを解除し、`wpautop` の状態を必要なら復元する
+	 *
+	 * 通常はテスト本体側で `add_filter( 'the_content', 'wpautop' )` を戻しているが、
+	 * アサーション失敗等で途中終了した場合に備えて、set_up 時点で登録されていた
+	 * 場合のみ ここで再登録して状態を揃える。
 	 */
 	public function tear_down() {
+		if ( $this->had_wpautop && false === has_filter( 'the_content', 'wpautop' ) ) {
+			add_filter( 'the_content', 'wpautop' );
+		}
 		remove_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10 );
 		parent::tear_down();
 	}
@@ -58,8 +85,11 @@ class BlogCardTest extends WP_UnitTestCase {
 	 * @return false|array|WP_Error vektor-inc.co.jp なら WP_Error、それ以外は $pre をそのまま返す
 	 */
 	public function mock_http_fail( $pre, $args, $url ) {
-		// vektor-inc.co.jp 宛てのリクエストのみ失敗扱いに固定する
-		if ( false !== strpos( $url, 'vektor-inc.co.jp' ) ) {
+		// クエリ文字列やパスに 'vektor-inc.co.jp' が含まれているケースで誤反応しないよう、
+		// `wp_parse_url` で host を厳密に取り出してマッチングする。
+		// 末尾一致＋直前が `.` であれば許可することでサブドメイン（例: blog.vektor-inc.co.jp）も拾う。
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( is_string( $host ) && preg_match( '/(^|\.)vektor-inc\.co\.jp$/i', $host ) ) {
 			return new \WP_Error( 'http_request_failed', 'mocked' );
 		}
 		// それ以外のドメインは通常通り処理させる


### PR DESCRIPTION
Closes #1328

## 概要

`_g3/tests/test-vk-wp-oembed-blog-card.php` の `Vk get post data blog card` テストが、CI ランナーから `vektor-inc.co.jp` への OGP 取得が成功するか否かで PASS / FAIL が変動する flaky test 化していた。期待値（テストコード側）は「OGP 取得失敗時の URL のみフォールバック表示」を想定しているが、実際は外部サイトへの到達可否によって OGP 取得成功時のリッチカード HTML が返るケースがあり、テストロジック側が外部 API レスポンスを固定値として期待しているのが根本原因。

無関係な PR（#1327 など）の CI を巻き込んで falsely fail させるため、本 PR では外部 HTTP を**モック**して結果を固定する方針で対応。

## 対応方針

issue #1328 のコメント（[#1328 issuecomment-4426289963](https://github.com/vektor-inc/lightning/issues/1328#issuecomment-4426289963)）で合意した仕様提案に沿って実装。

- `set_up()` / `tear_down()` で `pre_http_request` フィルタを登録・解除する
- `mock_http_fail()` で `vektor-inc.co.jp` 宛てのリクエストのみ `WP_Error` を返して「失敗」扱いに固定する
- YouTube oEmbed や内部リンクなど、他ドメインのリクエストは `$pre` をそのまま返して通常処理に流す
- 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed discovery）にも同じモックを効かせる必要があるため、`set_up` 段階でフィルタ登録する設計

これにより、外部ネットワーク状況に関係なく**常に「フォールバック HTML（URL のみのリンク）」のケース**を検証できる。

## 変更ファイル

- `_g3/tests/test-vk-wp-oembed-blog-card.php`（テストファイルのみ）

本体ロジック（`vk-wp-oembed-blog-card` の実装）には一切変更なし。

## 確認手順

### 前提条件

- Lightning G3 の PHPUnit 環境が利用できること（`composer install` 済み）
- リポジトリルートで `phpunit.g3.xml` 経由のテストが実行できること

### 手順

#### Before（修正前の再現手順）

1. リポジトリルートで以下を実行する
   \`\`\`
   ./vendor/bin/phpunit -c phpunit.g3.xml _g3/tests/test-vk-wp-oembed-blog-card.php
   \`\`\`
2. CI 環境や外部 API の応答状況によっては、`test_vk_get_post_data_blog_card` の期待値（URL のみのフォールバック HTML）と実出力（OGP リッチカード HTML）が一致せず FAIL となる
   → ✗ flaky に PASS / FAIL が変動する

#### After（修正後の確認手順）

1. 本ブランチ（`fix/1328-oembed-blog-card-flaky-test`）をチェックアウト
2. リポジトリルートで以下を実行する
   \`\`\`
   ./vendor/bin/phpunit -c phpunit.g3.xml _g3/tests/test-vk-wp-oembed-blog-card.php
   \`\`\`
   → ✓ `OK (22 tests, 139 assertions)` となること（外部ネットワーク状況に依存しない）
3. ネットワークを切断した状態（または `vektor-inc.co.jp` へ到達できない状況）で再度同じコマンドを実行する
   → ✓ 同じく `OK (22 tests, 139 assertions)` となること（モックで失敗固定しているため結果が変わらない）
4. 念のため `_g3` の全テストを実行してリグレッションがないことを確認する
   \`\`\`
   ./vendor/bin/phpunit -c phpunit.g3.xml
   \`\`\`
   → ✓ 既存テストにデグレが発生しないこと

## changelog について

本 PR はテストファイルのみの修正で、テーマ本体ロジック・エンドユーザー向け挙動には一切変更がない。`rules/changelog.md` の「更新不要なケース」（開発環境の設定変更 / エンドユーザーに影響しない変更）に該当するため、エンドユーザー向け `readme.txt` の Changelog セクションへの追記は不要と判断。

## セキュリティレビュー

安藤によるセキュリティレビュー実施済み（PASS）。テストファイル内に閉じたモック実装であり、本番コードパスへの影響なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テスト環境のセットアップとクリーンアップ処理が強化されました。外部サービスへのネットワークリクエストをシミュレートするモック機能が改善され、テスト実行の信頼性が向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->