### PR TITLE
[ 開発環境 ] e2e テストの固定 sleep を page.waitForFunction に置き換えてフレーク耐性を向上

### DIFF
--- a/tests/e2e/header-scroll-capture-flag.spec.js
+++ b/tests/e2e/header-scroll-capture-flag.spec.js
@@ -135,23 +135,25 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 			// 一度スクロールを発生させて handler が呼ばれる事を確認
 			await page.evaluate(() => window.scrollTo(0, 100));
-			await page.waitForTimeout(50);
+			// 固定 sleep ではなく __callCount が増えるまでポーリング待機する（フレーク耐性向上）
+			await page.waitForFunction(() => window.__callCount > 0);
 			const countBeforeRemove = await page.evaluate(() => window.__callCount);
 			expect(countBeforeRemove).toBeGreaterThan(0);
 
 			// removeEventListener を呼ぶ（capture: false 側）→ 修正前は無音失敗
 			await page.evaluate(() => window.__removeIt());
 
-			// もう一度スクロール
-			const callCountAfterRemove = await page.evaluate(() => {
-				window.__callCount = 0; // リセット
+			// もう一度スクロール（カウンタはリセットしてから発火）
+			await page.evaluate(() => {
+				window.__callCount = 0;
 				window.scrollTo(0, 200);
-				return new Promise((resolve) => {
-					setTimeout(() => resolve(window.__callCount), 100);
-				});
 			});
 
-			// 修正前の挙動: remove に失敗してリスナーが残るので呼ばれる
+			// 修正前の挙動: remove に失敗してリスナーが残っているはずなので、
+			// __callCount が増えるのを固定 sleep ではなくポーリングで待つ。
+			// もしリスナーが残っていなければ waitForFunction がタイムアウトしてテスト失敗となる。
+			await page.waitForFunction(() => window.__callCount > 0);
+			const callCountAfterRemove = await page.evaluate(() => window.__callCount);
 			expect(callCountAfterRemove).toBeGreaterThan(0);
 		});
 
@@ -161,19 +163,25 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 			// スクロールで handler が呼ばれる事を確認
 			await page.evaluate(() => window.scrollTo(0, 100));
-			await page.waitForTimeout(50);
+			// 固定 sleep ではなく __callCount が増えるまでポーリング待機する
+			await page.waitForFunction(() => window.__callCount > 0);
 			const countBeforeRemove = await page.evaluate(() => window.__callCount);
 			expect(countBeforeRemove).toBeGreaterThan(0);
 
 			// removeEventListener を呼ぶ（capture: false 側、登録側も capture: false）→ 成功
 			await page.evaluate(() => window.__removeIt());
 
-			// もう一度スクロール
+			// もう一度スクロール（カウンタはリセットしてから発火）。
+			// 「増えない」ことを確認するケースは、ポーリングだけでは「まだ未到達」と区別が付かないため、
+			// scroll イベントの dispatch / 反映が確実に終わるまで requestAnimationFrame を 2 フレーム待つ。
 			const callCountAfterRemove = await page.evaluate(() => {
-				window.__callCount = 0; // リセット
+				window.__callCount = 0;
 				window.scrollTo(0, 200);
 				return new Promise((resolve) => {
-					setTimeout(() => resolve(window.__callCount), 100);
+					// 2 RAF 待ってからカウンタを評価する（scroll イベントが処理されるまで待機）
+					requestAnimationFrame(() => {
+						requestAnimationFrame(() => resolve(window.__callCount));
+					});
 				});
 			});
 
@@ -186,13 +194,19 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 			// 一度 remove
 			await page.evaluate(() => window.__removeIt());
-			// scroll しても呼ばれないこと
-			await page.evaluate(() => {
+
+			// scroll しても呼ばれないことを確認。
+			// 「増えない」ことの確認は固定 sleep ではなく 2 RAF 待ちで scroll イベント処理を flush する。
+			const countAfterRemove = await page.evaluate(() => {
 				window.__callCount = 0;
 				window.scrollTo(0, 100);
+				return new Promise((resolve) => {
+					requestAnimationFrame(() => {
+						requestAnimationFrame(() => resolve(window.__callCount));
+					});
+				});
 			});
-			await page.waitForTimeout(50);
-			expect(await page.evaluate(() => window.__callCount)).toBe(0);
+			expect(countAfterRemove).toBe(0);
 
 			// PR 修正後と等価な capture: false 再登録
 			await page.evaluate(() => window.__reAddIt());
@@ -202,7 +216,8 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 				window.__callCount = 0;
 				window.scrollTo(0, 200);
 			});
-			await page.waitForTimeout(50);
+			// 固定 sleep ではなく __callCount が増えるまでポーリング待機する
+			await page.waitForFunction(() => window.__callCount > 0);
 			expect(await page.evaluate(() => window.__callCount)).toBeGreaterThan(0);
 		});
 
@@ -218,10 +233,20 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 				window.__callCount = 0;
 				window.scrollTo(0, 100);
 			});
-			await page.waitForTimeout(50);
+
+			// 固定 sleep ではなく __callCount が 1 以上になるまでポーリング待機する。
+			// 重複登録があれば 2 以上に増えてしまうため、その後 2 RAF 待って
+			// scroll イベントが完全に処理されたタイミングで最終値を評価する。
+			await page.waitForFunction(() => window.__callCount >= 1);
+			const count = await page.evaluate(() => {
+				return new Promise((resolve) => {
+					requestAnimationFrame(() => {
+						requestAnimationFrame(() => resolve(window.__callCount));
+					});
+				});
+			});
 
 			// 重複登録されていれば 2 以上になるが、PR 修正後は 1 のみ
-			const count = await page.evaluate(() => window.__callCount);
 			expect(count).toBe(1);
 		});
 	});

--- a/tests/e2e/header-scroll-capture-flag.spec.js
+++ b/tests/e2e/header-scroll-capture-flag.spec.js
@@ -88,6 +88,37 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 	test.describe('挙動検証: capture フラグ不一致 vs 一致でのリスナー解除挙動', () => {
 		/**
+		 * 共通ヘルパー: requestAnimationFrame を 2 フレーム待ってから window.__callCount を返す。
+		 *
+		 * - 「scroll しても増えないこと」を確認するケースでは、ポーリングだけでは
+		 *   「まだ未到達」と「本当に増えない」が区別できないので、scroll イベントの
+		 *   dispatch / 反映が確実に終わるタイミングまで 2 RAF 待ってから値を読む必要がある。
+		 * - scrollY を指定した場合: __callCount をリセットして window.scrollTo(0, scrollY) を発火し、
+		 *   2 RAF 後の __callCount を返す。
+		 * - scrollY を省略した場合: scroll は発火せず、その時点から 2 RAF 待った後の __callCount を返す
+		 *   （事前に scroll + waitForFunction で 1 回呼ばれていることを確認しておいた値を flush するための用途）。
+		 *
+		 * @param {import('@playwright/test').Page} page Playwright の page インスタンス
+		 * @param {number|null} scrollY スクロール先 Y 座標。null を渡すと scroll は発火しない
+		 * @returns {Promise<number>} 2 RAF 待機後の window.__callCount
+		 */
+		async function getCallCountAfterTwoRaf(page, scrollY = null) {
+			return page.evaluate((y) => {
+				// scrollY が指定されていればカウンタをリセットして scroll を発火する
+				if (y !== null) {
+					window.__callCount = 0;
+					window.scrollTo(0, y);
+				}
+				// 2 RAF 待ってから __callCount を返す（scroll イベントの処理が確実に終わるまで待機）
+				return new Promise((resolve) => {
+					requestAnimationFrame(() => {
+						requestAnimationFrame(() => resolve(window.__callCount));
+					});
+				});
+			}, scrollY);
+		}
+
+		/**
 		 * 修正前の挙動を再現する HTML（PR 修正前と同じ捕捉フラグ不一致）
 		 * addEventListener('scroll', fn, true) ＋ removeEventListener('scroll', fn) の組み合わせ
 		 * → removeEventListener は capture: false を見るので、対象が無く無音失敗する。
@@ -173,17 +204,8 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 			// もう一度スクロール（カウンタはリセットしてから発火）。
 			// 「増えない」ことを確認するケースは、ポーリングだけでは「まだ未到達」と区別が付かないため、
-			// scroll イベントの dispatch / 反映が確実に終わるまで requestAnimationFrame を 2 フレーム待つ。
-			const callCountAfterRemove = await page.evaluate(() => {
-				window.__callCount = 0;
-				window.scrollTo(0, 200);
-				return new Promise((resolve) => {
-					// 2 RAF 待ってからカウンタを評価する（scroll イベントが処理されるまで待機）
-					requestAnimationFrame(() => {
-						requestAnimationFrame(() => resolve(window.__callCount));
-					});
-				});
-			});
+			// ヘルパー経由で scroll → 2 RAF 待機 → __callCount を取得する。
+			const callCountAfterRemove = await getCallCountAfterTwoRaf(page, 200);
 
 			// 修正後の挙動: remove に成功してリスナーが消えるので呼ばれない
 			expect(callCountAfterRemove).toBe(0);
@@ -197,15 +219,7 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 
 			// scroll しても呼ばれないことを確認。
 			// 「増えない」ことの確認は固定 sleep ではなく 2 RAF 待ちで scroll イベント処理を flush する。
-			const countAfterRemove = await page.evaluate(() => {
-				window.__callCount = 0;
-				window.scrollTo(0, 100);
-				return new Promise((resolve) => {
-					requestAnimationFrame(() => {
-						requestAnimationFrame(() => resolve(window.__callCount));
-					});
-				});
-			});
+			const countAfterRemove = await getCallCountAfterTwoRaf(page, 100);
 			expect(countAfterRemove).toBe(0);
 
 			// PR 修正後と等価な capture: false 再登録
@@ -237,14 +251,10 @@ test.describe('PR #1332: header_scroll_func capture フラグ修正', () => {
 			// 固定 sleep ではなく __callCount が 1 以上になるまでポーリング待機する。
 			// 重複登録があれば 2 以上に増えてしまうため、その後 2 RAF 待って
 			// scroll イベントが完全に処理されたタイミングで最終値を評価する。
+			// scroll はすでに発火済みなのでヘルパーには scrollY を渡さず、
+			// 2 RAF 待ちのみ実行して flush 後の __callCount を取得する。
 			await page.waitForFunction(() => window.__callCount >= 1);
-			const count = await page.evaluate(() => {
-				return new Promise((resolve) => {
-					requestAnimationFrame(() => {
-						requestAnimationFrame(() => resolve(window.__callCount));
-					});
-				});
-			});
+			const count = await getCallCountAfterTwoRaf(page);
 
 			// 重複登録されていれば 2 以上になるが、PR 修正後は 1 のみ
 			expect(count).toBe(1);


### PR DESCRIPTION
## 関連 issue

closes #1336

## 概要

`tests/e2e/header-scroll-capture-flag.spec.js` で使用していた固定 sleep（`page.waitForTimeout(50)` と `setTimeout(() => resolve(...), 100)`）を、ポーリング条件付き待機に置き換えてフレーク耐性を向上させました。

## 変更内容

### 1. 「callCount が増えること」を待つケース → `page.waitForFunction` に置換

旧 L138 / L165、および reAdd 後の検証部分は、scroll イベントで `window.__callCount` が増えることを待つために 50ms の固定 sleep を使っていました。これを以下に置換しています。

```js
await page.waitForFunction(() => window.__callCount > 0);
```

リスナーが残っていない／再登録されていない場合は waitForFunction がタイムアウトして自然にテスト失敗するため、検証意図とも整合します。

### 2. 「callCount が増えないこと」を確認するケース → `requestAnimationFrame` 2 フレーム待ちに置換

旧 L150 / L176 / L194 では `setTimeout(() => resolve(window.__callCount), 100)` で 100ms 経過後に「増えていないこと」を確認していました。ここはポーリングだけだと「まだ未到達」と「本当に増えない」を区別できないため、`requestAnimationFrame` を 2 フレーム待ってから値を評価する形にしています。

```js
const count = await page.evaluate(() => {
    window.__callCount = 0;
    window.scrollTo(0, 200);
    return new Promise((resolve) => {
        // 2 RAF 待って scroll イベントが処理されるまで待機
        requestAnimationFrame(() => {
            requestAnimationFrame(() => resolve(window.__callCount));
        });
    });
});
```

固定 100ms より、scroll イベントの dispatch / 反映完了を待つという意味で挙動が明確になります。

### 3. 「ちょうど 1 回だけ呼ばれる」ケース → `waitForFunction` + 2 RAF flush の合わせ技

旧 L221（重複登録なしの検証）は、`waitForFunction(() => window.__callCount >= 1)` で 1 回呼ばれるのを待ったあと、さらに 2 RAF 待って scroll イベントを完全に flush してから `expect(count).toBe(1)` で評価しています。重複登録があれば 2 以上になるので検出可能です。

## 確認手順

### 前提条件
- `npm install` 済み（Playwright および各ブラウザバイナリがインストールされていること）

### 手順
1. 本ブランチを checkout する
2. 以下のコマンドで対象テストを実行する
   ```bash
   npx playwright test tests/e2e/header-scroll-capture-flag.spec.js --reporter=list
   ```
   → 全 21 テスト（chromium / firefox / webkit × 7 テスト）が PASS する
3. （任意）数回連続で実行し、フレーキー挙動が出ないことを確認する
   ```bash
   for i in 1 2 3; do npx playwright test tests/e2e/header-scroll-capture-flag.spec.js --reporter=line; done
   ```
   → いずれの実行でも全テストが安定して PASS する

### ローカル実行結果

- chromium / firefox / webkit 全 21 テスト PASS（実行時間: 約 17.6s）

## changelog について

今回は changelog の更新を行っていません。理由は以下のとおりです。

- 変更は `tests/e2e/` 配下のみで、`_g2/` / `_g3/` のプロダクトコードへの変更は含まれない
- このリポジトリの changelog ファイルは `readme.txt`（WordPress.org 公開用）のみで、`CHANGELOG.md` は存在しない
- `rules/changelog.md` および `rules/change-types.md` のルール上、`[ 開発環境 ]` の変更は WordPress.org の `readme.txt` には記載しない

## 補足

- Lightning 固有ルール（CLAUDE.md）に従い、`_g2/` / `_g3/` への変更がないため PR タイトルに G2/G3 プレフィックスは付けていません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * スクロール関連のテストにおいて、タイミングの不安定性を軽減するため、固定遅延をポーリングメカニズムに置き換え、テストの信頼性を向上させました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->