### PR TITLE
[ G3 ][ 不具合修正 ] Snow Monkey Forms のセレクトボックスで矢印が二重表示になる問題を修正

### DIFF
--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -381,6 +381,9 @@ if ( is_plugin_active( 'booking-package/index.php' ) ) {
 if ( is_plugin_active( 'contact-form-7/wp-contact-form-7.php' ) ) {
 	require __DIR__ . '/plugin-support/contact-form-7/functions-contact-form-7.php';
 }
+if ( is_plugin_active( 'snow-monkey-forms/snow-monkey-forms.php' ) ) {
+	require __DIR__ . '/plugin-support/snow-monkey-forms/functions-snow-monkey-forms.php';
+}
 
 /**
  * Disable_tgm_notification_except_admin

--- a/_g3/plugin-support/snow-monkey-forms/_scss/style.scss
+++ b/_g3/plugin-support/snow-monkey-forms/_scss/style.scss
@@ -1,0 +1,5 @@
+// Snow Monkey Forms の select コントロールはプラグイン独自の toggle 矢印を持つため、
+// テーマ側の background-image 矢印を無効化する
+.smf-form .smf-select-control__control {
+	background-image: none;
+}

--- a/_g3/plugin-support/snow-monkey-forms/css/style.css
+++ b/_g3/plugin-support/snow-monkey-forms/css/style.css
@@ -1,0 +1,1 @@
+.smf-form .smf-select-control__control{background-image:none}

--- a/_g3/plugin-support/snow-monkey-forms/functions-snow-monkey-forms.php
+++ b/_g3/plugin-support/snow-monkey-forms/functions-snow-monkey-forms.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Snow Monkey Forms Extension
+ *
+ * @package         Lightning
+ */
+
+/*
+	CSS読み込み
+/*-------------------------------------------*/
+function lightning_snow_monkey_forms_load_css() {
+	wp_enqueue_style( 'lightning-snow-monkey-forms-style', get_template_directory_uri() . '/plugin-support/snow-monkey-forms/css/style.css', array(), LIGHTNING_THEME_VERSION );
+}
+add_action( 'wp_enqueue_scripts', 'lightning_snow_monkey_forms_load_css' );

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -286,6 +286,17 @@ gulp.task('sass_common_g3', function (done) {
 		  .pipe(gulp.dest('./_g3/plugin-support/booking-package/css/'))
 	  });
 
+	gulp.task('sass_snow_monkey_forms_g3', function (done) {
+		return src(['./_g3/plugin-support/snow-monkey-forms/_scss/**.scss'])
+		  .pipe(sass())
+		  .pipe(cmq({
+			log: true
+		  }))
+		  .pipe(autoprefixer())
+		  .pipe(cleanCss())
+		  .pipe(gulp.dest('./_g3/plugin-support/snow-monkey-forms/css/'))
+	  });
+
   // Watch
 gulp.task('watch_g3', function (done) {
 	error_stop = false
@@ -295,6 +306,7 @@ gulp.task('watch_g3', function (done) {
 	gulp.watch(['./_g3/plugin-support/bbpress/_scss/**'], gulp.series('sass_bbpress_g3'));
 	gulp.watch(['./_g3/plugin-support/the-events-calendar/_scss/**'], gulp.series('sass_the_event_calendar_g3'));
 	gulp.watch(['./_g3/plugin-support/booking-package/_scss/**'], gulp.series('sass_booking_package_g3'));
+	gulp.watch(['./_g3/plugin-support/snow-monkey-forms/_scss/**'], gulp.series('sass_snow_monkey_forms_g3'));
 	done();
 });
 
@@ -311,12 +323,13 @@ gulp.task('watch', function (done) {
 	gulp.watch(['./_g3/plugin-support/bbpress/_scss/**'], gulp.series('sass_bbpress_g3'));
 	gulp.watch(['./_g3/plugin-support/the-events-calendar/_scss/**'], gulp.series('sass_the_event_calendar_g3'));
 	gulp.watch(['./_g3/plugin-support/booking-package/_scss/**'], gulp.series('sass_booking_package_g3'));
+	gulp.watch(['./_g3/plugin-support/snow-monkey-forms/_scss/**'], gulp.series('sass_snow_monkey_forms_g3'));
 	done();
-});	
-  
+});
+
 gulp.task('default',  gulp.series( 'watch'));
 // _g3/assets/_scss/style-theme-json.sass が _g3/assets/css/を読み込んでいるため２回まわしている.
-gulp.task('sass_g3',  gulp.series( 'sass_common_g3', 'sass_common_g3', 'sass_skin_g3', 'sass_woo_g3', 'sass_bbpress_g3', 'sass_the_event_calendar_g3', 'sass_booking_package_g3' ));
+gulp.task('sass_g3',  gulp.series( 'sass_common_g3', 'sass_common_g3', 'sass_skin_g3', 'sass_woo_g3', 'sass_bbpress_g3', 'sass_the_event_calendar_g3', 'sass_booking_package_g3', 'sass_snow_monkey_forms_g3' ));
 gulp.task('dist_g3',  gulp.series( 'text-domain', 'sass_g3' ));
 
 gulp.task('sass',  gulp.series( 'sass_g2', 'sass_g3' ));

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G3 ][ Bug Fix ] Fix double arrow display in Snow Monkey Forms select box caused by Lightning's SVG background-image arrow conflicting with Snow Monkey Forms' own toggle arrow
+
 v15.35.2
 [ G2 ][ Bug Fix ] Fix initial `scroll` listener registered with `capture: true` not being removed by `remove_header` because `removeEventListener` used `capture: false`, leaving duplicated `scroll` listeners attached after in-page anchor clicks (#1333)
 [ G2/G3 ][ Bug Fix ] Fix scroll listener being left attached after in-page anchor clicks because `addEventListener` re-registered `header_scroll_func` with `capture: true` while `removeEventListener` used `capture: false`, causing the `header_scrolled` class to behave inconsistently


### PR DESCRIPTION
## 概要

PR #1323 で `select` 要素に `background-image` で SVG 矢印を追加した際に、Snow Monkey Forms のセレクトボックスにも適用されてしまい、SMF 独自の toggle 矢印と二重表示になる問題を修正します。

## 関連するフォーラム
https://vws.vektor-inc.co.jp/forums/topic/%e3%80%90%e6%a9%9f%e8%83%bd%e8%bf%bd%e5%8a%a0%e8%a6%81%e6%9c%9b%e3%80%91%e3%81%8a%e5%95%8f%e3%81%84%e5%90%88%e3%82%8f%e3%81%9b%e3%81%ae%e3%82%bb%e3%83%ac%e3%82%af%e3%83%88%e3%83%9c%e3%83%83%e3%82%af

### 原因

`_g3/assets/_scss/_common.scss` に追加した以下のルールが SMF の `<select>` にも適用されていた：

```css
select:where(:not([multiple]):not([size])) {
  background-image: url("...SVG矢印..."); /* Lightning の矢印 */
}
```

SMF は `.smf-select-control__toggle::before` で独自の矢印を持っており、両方が表示されて二重になっていた。

### 修正内容

`_g3/plugin-support/snow-monkey-forms/` を新設し、SMF がアクティブな場合のみ以下の CSS を読み込む：

```css
.smf-form .smf-select-control__control {
  background-image: none;
}
```

これにより Lightning 側の background-image 矢印が除外され、SMF 独自の toggle 矢印のみが表示される。

▼プラグイン側の矢印を優先した背景は以下になります。

① SMF のトグル矢印は「見た目だけ」ではなく、フォーカス状態のスタイル変化も担っている

style-index.css を見ると、フォーカス時に矢印の色が変わる仕様になっています：


.smf-select-control__control:focus + .smf-select-control__toggle:before {
  border-color: #3a87fd;
}
Lightning の background-image 矢印はこのフォーカス連動を持ちません。SMF 側の矢印を消してしまうと、フォーカス時の視覚フィードバックも失われます。

② SMF はエディタ側で自ら background-image: none を適用していた

SMF の index.css（エディタ用 CSS）には既に：


.smf-form .smf-select-control__control { background-image: none !important; }
が含まれています。プラグイン作者がテーマ側の矢印との競合を想定してエディタ側で対処していた形跡であり、「フロントエンドでも同じ意図だが記載漏れだった」と解釈できます。

③ テーマの一般ルールを、プラグイン固有の UI コンポーネントに干渉させない

Lightning の select:where(:not([multiple]):not([size])) は、CF7 のような「ネイティブな <select>」を対象に追加した汎用ルールです。一方 SMF の .smf-select-control は、ネイティブ <select> をラップして構築されたプラグイン独自のカスタム UI コンポーネントであり、テーマの汎用スタイルが及ぶべき対象ではありません。


## 確認手順

### 前提条件
- Lightning G3 テーマを有効化
- Snow Monkey Forms プラグインをインストール・有効化
- Snow Monkey Forms でセレクトボックスを含むフォームを作成し、固定ページや投稿に設置

### Before（修正前の再現手順）
1. フォームが設置されたページを公開側で開く
2. セレクトボックスを確認する
   → ✗ 矢印が2つ表示される（Lightning の ▽ と SMF の › が並んで表示）

### After（修正後の確認手順）
1. フォームが設置されたページを公開側で開く
2. セレクトボックスを確認する
   → ✓ SMF 独自の矢印のみが1つ表示される（二重表示が解消）
3. Contact Form 7 のセレクトボックスが設置されているページを確認する
   → ✓ CF7 は影響を受けず、Lightning の矢印が引き続き表示される

## スクリーンショット

### Before
（矢印が2つ表示されている状態 — VWSフォーラム報告の添付画像参照）

### After
修正後は SMF 独自の矢印のみ表示される。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Snow Monkey Forms プラグインのサポートを追加しました。

* **バグ修正**
  * Snow Monkey Forms のセレクトボックスに表示されていたダブルアロー（矢印の重複）の問題を修正しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/lightning/pull/1341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->