### PR TITLE
[ 仕様変更 ] vektor-inc/vk-component を 1.6.5 から 1.7.0 に更新

### DIFF
--- a/_g2/template-parts/post/loop-layout-use-component-sample.php
+++ b/_g2/template-parts/post/loop-layout-use-component-sample.php
@@ -8,6 +8,7 @@ $options = array(
 	'display_image_overlay_term' => true,
 	'display_excerpt'            => true,
 	'display_date'               => true,
+	'display_modified'           => false,
 	'display_new'                => true,
 	'display_btn'                => true,
 	'image_default_url'          => false,

--- a/_g2/template-parts/post/next-prev.php
+++ b/_g2/template-parts/post/next-prev.php
@@ -32,6 +32,7 @@ if ( $bootstrap == '4' ) {
 			'display_image_overlay_term' => true,
 			'display_excerpt'            => false,
 			'display_date'               => true,
+			'display_modified'           => false,
 			'display_btn'                => false,
 			'image_default_url'          => get_template_directory_uri() . '/assets/images/no-image.png',
 			'overlay'                    => '',

--- a/_g2/tests/test-vk-component-posts-display-modified.php
+++ b/_g2/tests/test-vk-component-posts-display-modified.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * VK_Component_Posts の display_modified（更新日表示）オプションのテスト
+ *
+ * vk-component 1.7.0 で追加された「更新日表示（display_modified）」を
+ * テーマのテンプレートが使うレイアウト（media / card-intext / card-horizontal）で
+ * 期待通りに描画できるかを検証する。
+ *
+ * @package Lightning G2
+ */
+
+use VektorInc\VK_Component\VK_Component_Posts;
+
+/**
+ * VK_Component_Posts_Display_Modified_Test
+ */
+class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
+
+	/**
+	 * VK_Component_Posts::get_view() が display_modified を反映するか
+	 *
+	 * @return void
+	 */
+	public function test_get_view() {
+
+		// テスト用の投稿を1件作成（このIDを各ケースで使い回す）.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'display_modified テスト投稿',
+				'post_status'  => 'publish',
+				'post_content' => 'content',
+			)
+		);
+		$post = get_post( $post_id );
+
+		// 各レイアウト共通の基本オプション（テンプレートの指定に合わせた最小構成）.
+		$base_options = array(
+			'display_image'              => false,
+			'display_image_overlay_term' => false,
+			'display_excerpt'            => false,
+			'display_new'                => false,
+			'display_btn'                => false,
+		);
+
+		// テストの配列（条件と、出力HTMLに含まれる／含まれないべきマーカーをまとめて登録）.
+		$test_array = array(
+			array(
+				// 更新日ありの基本ケース（media レイアウト）.
+				'test_condition_name' => 'media レイアウトで display_modified が true の場合 => 更新日のマークアップが出力される',
+				'options'             => array(
+					'layout'           => 'media',
+					'display_date'     => true,
+					'display_modified' => true,
+				),
+				// マーカー => 含まれるべきか（true: 含む / false: 含まない）.
+				'assertions'          => array(
+					'-date modified'       => true,
+					'fa-clock-rotate-left' => true,
+				),
+			),
+			array(
+				// 公開日と更新日の両方を表示するケース（card-intext レイアウト）.
+				'test_condition_name' => 'card-intext で display_date と display_modified が両方 true の場合 => 公開日と更新日の両方が出力される',
+				'options'             => array(
+					'layout'           => 'card-intext',
+					'display_date'     => true,
+					'display_modified' => true,
+				),
+				'assertions'          => array(
+					'-date published' => true,
+					'-date modified'  => true,
+				),
+			),
+			array(
+				// テーマの現状（display_modified を false で明示）= 更新日は出ない.
+				'test_condition_name' => 'media レイアウトで display_modified が false の場合 => 更新日のマークアップは出力されない',
+				'options'             => array(
+					'layout'           => 'media',
+					'display_date'     => true,
+					'display_modified' => false,
+				),
+				'assertions'          => array(
+					'-date published' => true,
+					'-date modified'  => false,
+				),
+			),
+			array(
+				// 境界値: 公開日も更新日も非表示なら日付ブロック自体が出力されない.
+				'test_condition_name' => 'card-horizontal で display_date も display_modified も false の場合 => 日付ブロックが出力されない',
+				'options'             => array(
+					'layout'           => 'card-horizontal',
+					'display_date'     => false,
+					'display_modified' => false,
+				),
+				'assertions'          => array(
+					'vk_post_dates' => false,
+				),
+			),
+		);
+
+		print PHP_EOL;
+		print '★★★★★-------------------------------' . PHP_EOL;
+		print 'VK_Component_Posts::get_view() display_modified' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		foreach ( $test_array as $case ) {
+			// 基本オプションにケース固有のオプションをマージ.
+			$options = array_merge( $base_options, $case['options'] );
+
+			// 描画結果のHTMLを取得（the_view ではなく get_view で生のHTMLを取得）.
+			$actual = VK_Component_Posts::get_view( $post, $options );
+
+			print PHP_EOL;
+			print $case['test_condition_name'] . PHP_EOL;
+			print 'return  :' . $actual . PHP_EOL;
+
+			// マーカー毎に、含まれる／含まれないを検証.
+			foreach ( $case['assertions'] as $marker => $should_contain ) {
+				if ( $should_contain ) {
+					$this->assertStringContainsString( $marker, $actual, $case['test_condition_name'] . ' / ' . $marker );
+				} else {
+					$this->assertStringNotContainsString( $marker, $actual, $case['test_condition_name'] . ' / ' . $marker );
+				}
+			}
+		}
+
+		// 後始末: テスト用投稿を削除.
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/_g2/tests/test-vk-component-posts-display-modified.php
+++ b/_g2/tests/test-vk-component-posts-display-modified.php
@@ -31,6 +31,9 @@ class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
 				'post_content' => 'content',
 			)
 		);
+		// 投稿が正常に作成されたことを確認（0 や WP_Error でないこと）.
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
 		$post = get_post( $post_id );
 
 		// 各レイアウト共通の基本オプション（テンプレートの指定に合わせた最小構成）.
@@ -98,21 +101,12 @@ class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
 			),
 		);
 
-		print PHP_EOL;
-		print '★★★★★-------------------------------' . PHP_EOL;
-		print 'VK_Component_Posts::get_view() display_modified' . PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-
 		foreach ( $test_array as $case ) {
 			// 基本オプションにケース固有のオプションをマージ.
 			$options = array_merge( $base_options, $case['options'] );
 
 			// 描画結果のHTMLを取得（the_view ではなく get_view で生のHTMLを取得）.
 			$actual = VK_Component_Posts::get_view( $post, $options );
-
-			print PHP_EOL;
-			print $case['test_condition_name'] . PHP_EOL;
-			print 'return  :' . $actual . PHP_EOL;
 
 			// マーカー毎に、含まれる／含まれないを検証.
 			foreach ( $case['assertions'] as $marker => $should_contain ) {

--- a/_g3/template-parts/loop-item.php
+++ b/_g3/template-parts/loop-item.php
@@ -15,6 +15,7 @@ $options = array(
 	'display_image_overlay_term' => true,
 	'display_excerpt'            => true,
 	'display_date'               => true,
+	'display_modified'           => false,
 	'display_new'                => true,
 	'display_taxonomies'         => false,
 	'display_btn'                => true,

--- a/_g3/template-parts/next-prev.php
+++ b/_g3/template-parts/next-prev.php
@@ -24,6 +24,7 @@ if ( $post_previous || $post_next ) {
 		'display_excerpt'            => false,
 		'display_title'               => false,
 		'display_date'               => true,
+		'display_modified'           => false,
 		'display_btn'                => false,
 		'image_default_url'          => get_template_directory_uri() . '/assets/images/no-image.png',
 		'overlay'                    => '',

--- a/_g3/template-parts/sidebar-contents-post.php
+++ b/_g3/template-parts/sidebar-contents-post.php
@@ -45,6 +45,7 @@ $post_loop = new WP_Query(
 			'display_image_overlay_term' => true,
 			'display_excerpt'            => false,
 			'display_date'               => true,
+			'display_modified'           => false,
 			'display_new'                => true,
 			'display_btn'                => false,
 			'image_default_url'          => false,

--- a/_g3/tests/test-vk-component-posts-display-modified.php
+++ b/_g3/tests/test-vk-component-posts-display-modified.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * VK_Component_Posts の display_modified（更新日表示）オプションのテスト
+ *
+ * vk-component 1.7.0 で追加された「更新日表示（display_modified）」を
+ * テーマのテンプレートが使うレイアウト（media / card-intext / card-horizontal）で
+ * 期待通りに描画できるかを検証する。
+ *
+ * @package Lightning G3
+ */
+
+use VektorInc\VK_Component\VK_Component_Posts;
+
+/**
+ * VK_Component_Posts_Display_Modified_Test
+ */
+class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
+
+	/**
+	 * VK_Component_Posts::get_view() が display_modified を反映するか
+	 *
+	 * @return void
+	 */
+	public function test_get_view() {
+
+		// テスト用の投稿を1件作成（このIDを各ケースで使い回す）.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'display_modified テスト投稿',
+				'post_status'  => 'publish',
+				'post_content' => 'content',
+			)
+		);
+		$post = get_post( $post_id );
+
+		// 各レイアウト共通の基本オプション（テンプレートの指定に合わせた最小構成）.
+		$base_options = array(
+			'display_image'              => false,
+			'display_image_overlay_term' => false,
+			'display_excerpt'            => false,
+			'display_new'                => false,
+			'display_btn'                => false,
+		);
+
+		// テストの配列（条件と、出力HTMLに含まれる／含まれないべきマーカーをまとめて登録）.
+		$test_array = array(
+			array(
+				// 更新日ありの基本ケース（media レイアウト）.
+				'test_condition_name' => 'media レイアウトで display_modified が true の場合 => 更新日のマークアップが出力される',
+				'options'             => array(
+					'layout'           => 'media',
+					'display_date'     => true,
+					'display_modified' => true,
+				),
+				// マーカー => 含まれるべきか（true: 含む / false: 含まない）.
+				'assertions'          => array(
+					'-date modified'       => true,
+					'fa-clock-rotate-left' => true,
+				),
+			),
+			array(
+				// 公開日と更新日の両方を表示するケース（card-intext レイアウト）.
+				'test_condition_name' => 'card-intext で display_date と display_modified が両方 true の場合 => 公開日と更新日の両方が出力される',
+				'options'             => array(
+					'layout'           => 'card-intext',
+					'display_date'     => true,
+					'display_modified' => true,
+				),
+				'assertions'          => array(
+					'-date published' => true,
+					'-date modified'  => true,
+				),
+			),
+			array(
+				// テーマの現状（display_modified を false で明示）= 更新日は出ない.
+				'test_condition_name' => 'media レイアウトで display_modified が false の場合 => 更新日のマークアップは出力されない',
+				'options'             => array(
+					'layout'           => 'media',
+					'display_date'     => true,
+					'display_modified' => false,
+				),
+				'assertions'          => array(
+					'-date published' => true,
+					'-date modified'  => false,
+				),
+			),
+			array(
+				// 境界値: 公開日も更新日も非表示なら日付ブロック自体が出力されない.
+				'test_condition_name' => 'card-horizontal で display_date も display_modified も false の場合 => 日付ブロックが出力されない',
+				'options'             => array(
+					'layout'           => 'card-horizontal',
+					'display_date'     => false,
+					'display_modified' => false,
+				),
+				'assertions'          => array(
+					'vk_post_dates' => false,
+				),
+			),
+		);
+
+		print PHP_EOL;
+		print '★★★★★-------------------------------' . PHP_EOL;
+		print 'VK_Component_Posts::get_view() display_modified' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		foreach ( $test_array as $case ) {
+			// 基本オプションにケース固有のオプションをマージ.
+			$options = array_merge( $base_options, $case['options'] );
+
+			// 描画結果のHTMLを取得（the_view ではなく get_view で生のHTMLを取得）.
+			$actual = VK_Component_Posts::get_view( $post, $options );
+
+			print PHP_EOL;
+			print $case['test_condition_name'] . PHP_EOL;
+			print 'return  :' . $actual . PHP_EOL;
+
+			// マーカー毎に、含まれる／含まれないを検証.
+			foreach ( $case['assertions'] as $marker => $should_contain ) {
+				if ( $should_contain ) {
+					$this->assertStringContainsString( $marker, $actual, $case['test_condition_name'] . ' / ' . $marker );
+				} else {
+					$this->assertStringNotContainsString( $marker, $actual, $case['test_condition_name'] . ' / ' . $marker );
+				}
+			}
+		}
+
+		// 後始末: テスト用投稿を削除.
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/_g3/tests/test-vk-component-posts-display-modified.php
+++ b/_g3/tests/test-vk-component-posts-display-modified.php
@@ -31,6 +31,9 @@ class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
 				'post_content' => 'content',
 			)
 		);
+		// 投稿が正常に作成されたことを確認（0 や WP_Error でないこと）.
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
 		$post = get_post( $post_id );
 
 		// 各レイアウト共通の基本オプション（テンプレートの指定に合わせた最小構成）.
@@ -98,21 +101,12 @@ class VK_Component_Posts_Display_Modified_Test extends WP_UnitTestCase {
 			),
 		);
 
-		print PHP_EOL;
-		print '★★★★★-------------------------------' . PHP_EOL;
-		print 'VK_Component_Posts::get_view() display_modified' . PHP_EOL;
-		print '------------------------------------' . PHP_EOL;
-
 		foreach ( $test_array as $case ) {
 			// 基本オプションにケース固有のオプションをマージ.
 			$options = array_merge( $base_options, $case['options'] );
 
 			// 描画結果のHTMLを取得（the_view ではなく get_view で生のHTMLを取得）.
 			$actual = VK_Component_Posts::get_view( $post, $options );
-
-			print PHP_EOL;
-			print $case['test_condition_name'] . PHP_EOL;
-			print 'return  :' . $actual . PHP_EOL;
 
 			// マーカー毎に、含まれる／含まれないを検証.
 			foreach ( $case['assertions'] as $marker => $should_contain ) {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"vektor-inc/vk-breadcrumb": "^0.2.8",
 		"vektor-inc/vk-css-optimize": "^0.2.5",
 		"vektor-inc/tgm-plugin-activation": "^2.6.2",
-		"vektor-inc/vk-component": "^1.6.5",
+		"vektor-inc/vk-component": "^1.7.0",
 		"vektor-inc/vk-helpers": "^0.3.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c2826f64d07265b28aef599842b7537",
+    "content-hash": "c6f247484354cc68ae8c1e152d135900",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
@@ -205,20 +205,23 @@
         },
         {
             "name": "vektor-inc/vk-component",
-            "version": "1.6.5",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/vk-components.git",
-                "reference": "a40838c62957501db9bf250ca9b67a021c4b33d5"
+                "reference": "85e8a42ceeb54549a5844b0e7dd32c808294cf9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/vk-components/zipball/a40838c62957501db9bf250ca9b67a021c4b33d5",
-                "reference": "a40838c62957501db9bf250ca9b67a021c4b33d5",
+                "url": "https://api.github.com/repos/vektor-inc/vk-components/zipball/85e8a42ceeb54549a5844b0e7dd32c808294cf9d",
+                "reference": "85e8a42ceeb54549a5844b0e7dd32c808294cf9d",
                 "shasum": ""
             },
             "require": {
                 "vektor-inc/vk-term-color": "^0.7.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": ">=10"
             },
             "require-dev": {
                 "wp-phpunit/wp-phpunit": "^6.7",
@@ -243,9 +246,9 @@
             "description": "Vektor Component",
             "support": {
                 "issues": "https://github.com/vektor-inc/vk-components/issues",
-                "source": "https://github.com/vektor-inc/vk-components/tree/1.6.5"
+                "source": "https://github.com/vektor-inc/vk-components/tree/1.7.0"
             },
-            "time": "2025-01-01T02:17:35+00:00"
+            "time": "2026-06-22T03:36:12+00:00"
         },
         {
             "name": "vektor-inc/vk-css-optimize",
@@ -2517,5 +2520,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ Spec Change ] Update vektor-inc/vk-component from 1.6.5 to 1.7.0
+
 [ G3 ][ Design Bug Fix ] Fix global nav sub-menu acc-btn to be vertically centered when item title wraps to multiple lines (#724)
 
 v15.36.0


### PR DESCRIPTION
## 概要

composer 依存 `vektor-inc/vk-component` を `^1.6.5` から `^1.7.0` に更新し、`composer.lock` を 1.7.0（1.6.5 → 1.7.0）に追従させました。あわせて、投稿ループ系テンプレートで新オプション `display_modified` を `false` で明示指定し、既存の表示挙動を維持しています。

## 変更内容

- `composer.json`: `vektor-inc/vk-component` の制約を `^1.6.5` → `^1.7.0`
- `composer.lock`: `vektor-inc/vk-component` 1.6.5 → 1.7.0（他パッケージのバージョン変更なし）
- `readme.txt`: changelog に `[ Spec Change ] Update vektor-inc/vk-component from 1.6.5 to 1.7.0` を追記
- `_g2`/`_g3` の template-parts 計5ファイル: 新オプション `display_modified` を `false` で明示指定し、既存の表示挙動（更新日を表示しない）を維持
  - `_g2/template-parts/post/loop-layout-use-component-sample.php`
  - `_g2/template-parts/post/next-prev.php`
  - `_g3/template-parts/loop-item.php`
  - `_g3/template-parts/next-prev.php`
  - `_g3/template-parts/sidebar-contents-post.php`
- `_g2`/`_g3` に `display_modified` の表示挙動を検証する新規 PHPUnit テストを追加
  - `_g2/tests/test-vk-component-posts-display-modified.php`
  - `_g3/tests/test-vk-component-posts-display-modified.php`

※ vendor/ は git 管理外のためコミットには含めていません。

## 確認手順

### 前提条件
- ローカルで `composer install` 済みであること

### 手順
1. ブランチを checkout し、テーマディレクトリで `composer install` を実行する
   → ✓ エラーなく完了する
2. `composer show vektor-inc/vk-component` を実行する
   → ✓ versions に `1.7.0` が表示される
3. `grep -A1 '"name": "vektor-inc/vk-component"' composer.lock` を実行する
   → ✓ `"version": "1.7.0"` が表示される
4. テーマを有効化した WordPress でフロント／ブロックエディタを表示する
   → ✓ PHP エラー・表示崩れが発生しない（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 投稿カード/ループ/次前/サイドバー等で「更新日（modified）」の表示を抑制できるオプションを追加し、表示挙動を調整しました。  
* **Chores**
  * コンポーネント依存関係を `1.6.5` から `1.7.0` に更新しました。  
* **Tests**
  * レイアウト別に「更新日（modified）」の有無を確認するテストを追加しました。  
* **Documentation**
  * チェンジログに仕様変更（Spec Change）を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
