### PR TITLE
[ 仕様変更 ] vektor-inc/font-awesome-versions を 0.7.2 から 0.7.4 に更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	],
 	"require": {
 		"vektor-inc/vk-swiper": "^0.3.5",
-		"vektor-inc/font-awesome-versions": "0.7.3",
+		"vektor-inc/font-awesome-versions": "^0.7.4",
 		"vektor-inc/vk-color-palette-manager": "^0.4.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.8",
 		"vektor-inc/vk-css-optimize": "^0.2.5",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	],
 	"require": {
 		"vektor-inc/vk-swiper": "^0.3.5",
-		"vektor-inc/font-awesome-versions": "0.7.2",
+		"vektor-inc/font-awesome-versions": "0.7.3",
 		"vektor-inc/vk-color-palette-manager": "^0.4.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.8",
 		"vektor-inc/vk-css-optimize": "^0.2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6f247484354cc68ae8c1e152d135900",
+    "content-hash": "3734363e3bc2e42f39d3df603d61ed44",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4"
+                "reference": "e14185f2f58092bda72648bfb8f429005492ba89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/ec8458a56165dc309befe88c982a54bda4bcb2e4",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/e14185f2f58092bda72648bfb8f429005492ba89",
+                "reference": "e14185f2f58092bda72648bfb8f429005492ba89",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.2"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.3"
             },
-            "time": "2026-03-19T04:34:56+00:00"
+            "time": "2026-06-25T07:06:58+00:00"
         },
         {
             "name": "vektor-inc/tgm-plugin-activation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3734363e3bc2e42f39d3df603d61ed44",
+    "content-hash": "ef2616a52684110b1da6879b0edf521a",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "e14185f2f58092bda72648bfb8f429005492ba89"
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/e14185f2f58092bda72648bfb8f429005492ba89",
-                "reference": "e14185f2f58092bda72648bfb8f429005492ba89",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.3"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.4"
             },
-            "time": "2026-06-25T07:06:58+00:00"
+            "time": "2026-06-26T02:51:54+00:00"
         },
         {
             "name": "vektor-inc/tgm-plugin-activation",

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ vk-develop@vektor-inc.co.jp
 
 [ Spec Change ] Update vektor-inc/vk-component from 1.6.5 to 1.7.0
 
-[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.3
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4
 
 [ G3 ][ Design Bug Fix ] Fix global nav sub-menu acc-btn to be vertically centered when item title wraps to multiple lines (#724)
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,8 @@ vk-develop@vektor-inc.co.jp
 
 [ Spec Change ] Update vektor-inc/vk-component from 1.6.5 to 1.7.0
 
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.3
+
 [ G3 ][ Design Bug Fix ] Fix global nav sub-menu acc-btn to be vertically centered when item title wraps to multiple lines (#724)
 
 v15.36.0


### PR DESCRIPTION
## 概要

Composer 依存パッケージ `vektor-inc/font-awesome-versions` を 0.7.2 から **0.7.4** にアップデートします。

> **補足（0.7.3 を飛ばした理由）:** 当初 0.7.3 への更新を予定していましたが、**0.7.3 のリリースに同梱された woff2 webfont が破損**していました。バイナリが UTF-8 テキスト化され、`fa-solid-900.woff2` 等のヘッダ直後に `EF BF BD`（U+FFFD「置換文字」）が混入（fa-solid-900 で 47,488 箇所）。このためブラウザで以下のエラーとなり Font Awesome アイコンが一切表示されません。
>
> - `Failed to decode downloaded font`
> - `OTS parsing error: Size of decompressed WOFF 2.0 is less than compressed size`
>
> 0.7.4 で全 woff2（solid / regular / brands / v4compatibility）が修復されていることを確認したため、**0.7.3 を飛ばして 0.7.4 へ更新**します。

## 変更内容

- `composer.json`: `vektor-inc/font-awesome-versions` の制約を `^0.7.4` に変更（キャレット指定）
- `composer.lock`: 上記に伴い `vektor-inc/font-awesome-versions` を 0.7.4 に更新
- `readme.txt`: `== Changelog ==` の未リリースセクションに `[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4` を追記

## 確認手順

1. このブランチをチェックアウトし `composer install` を実行する
   → エラーなくインストールが完了する
2. `composer show vektor-inc/font-awesome-versions` を実行する
   → `versions : * 0.7.4` と表示される
3. `composer.lock` 内の `vektor-inc/font-awesome-versions` の `version` を確認する
   → `"version": "0.7.4"` になっている
4. Font Awesome アイコンを使用するページをフロントエンドで表示する
   → アイコンが正しく表示され、コンソールに `Failed to decode downloaded font` 等のエラーが出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Font Awesome 関連の依存関係バージョンを更新しました（0.7.2 → 0.7.4）。
  * 変更履歴（Changelog）に最新のバージョン情報を反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
