### PR TITLE
[ 不具合修正 ] PHP 8.1 以降でナビメニューアイテムの URL が null の場合に警告が記録される問題を修正

### DIFF
--- a/_g2/tests/test-widget-new-posts.php
+++ b/_g2/tests/test-widget-new-posts.php
@@ -45,12 +45,14 @@ class WidgetNewPostsTest extends WP_UnitTestCase {
 		);
 
 		// 空の $instance で form() を呼び出す（ウィジェット初回追加時と同等の状況）
+		// finally でクリーンアップを保証し、例外発生時も後続テストへの影響を防ぐ
 		ob_start();
-		$this->widget->form( array() );
-		ob_end_clean();
-
-		// エラーハンドラーを元に戻す
-		restore_error_handler();
+		try {
+			$this->widget->form( array() );
+		} finally {
+			ob_end_clean();
+			restore_error_handler();
+		}
 
 		// E_WARNING が発生していないことを確認する
 		$this->assertFalse( $warning_occurred, '空の $instance で form() を呼び出した際に E_WARNING が発生した' );

--- a/_g2/tests/test-widget-new-posts.php
+++ b/_g2/tests/test-widget-new-posts.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * WP_Widget_ltg_post_list ウィジェットのテスト
+ *
+ * @package vektor-inc/lightning
+ */
+
+/**
+ * WP_Widget_ltg_post_list の form() メソッドに関するテスト
+ */
+class WidgetNewPostsTest extends WP_UnitTestCase {
+
+	/**
+	 * テスト対象のウィジェットインスタンス
+	 *
+	 * @var WP_Widget_ltg_post_list
+	 */
+	private $widget;
+
+	/**
+	 * 各テスト前にウィジェットインスタンスを初期化する
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->widget = new WP_Widget_ltg_post_list();
+	}
+
+	/**
+	 * 空の $instance で form() を呼び出しても E_WARNING が発生しないことを確認する
+	 *
+	 * ウィジェット初回追加時（保存前）は $instance が空配列で渡されるため、
+	 * wp_parse_args() によるデフォルト値補完が正しく機能していることを検証する。
+	 */
+	public function test_form_with_empty_instance_does_not_trigger_warning() {
+		// E_WARNING が発生した場合にテストを失敗させるためのエラーハンドラーを登録する
+		$warning_occurred = false;
+		set_error_handler(
+			function( $errno, $errstr ) use ( &$warning_occurred ) {
+				if ( E_WARNING === $errno ) {
+					$warning_occurred = true;
+				}
+				// デフォルトのエラーハンドラーを実行しない
+				return true;
+			}
+		);
+
+		// 空の $instance で form() を呼び出す（ウィジェット初回追加時と同等の状況）
+		ob_start();
+		$this->widget->form( array() );
+		ob_end_clean();
+
+		// エラーハンドラーを元に戻す
+		restore_error_handler();
+
+		// E_WARNING が発生していないことを確認する
+		$this->assertFalse( $warning_occurred, '空の $instance で form() を呼び出した際に E_WARNING が発生した' );
+	}
+
+	/**
+	 * 空の $instance で form() を呼び出した際に、デフォルト値が正しく適用されることを確認する
+	 *
+	 * wp_parse_args() で設定されるデフォルト値が form() の出力に反映されることを検証する。
+	 */
+	public function test_form_with_empty_instance_uses_default_values() {
+		// form() の出力をキャプチャする
+		ob_start();
+		$this->widget->form( array() );
+		$output = ob_get_clean();
+
+		// デフォルト件数 10 が input の value に含まれることを確認する
+		$this->assertStringContainsString( 'value="10"', $output, 'デフォルトの表示件数（10）が form() の出力に含まれていない' );
+
+		// デフォルト投稿タイプ post が input の value に含まれることを確認する
+		$this->assertStringContainsString( 'value="post"', $output, 'デフォルトの投稿タイプ（post）が form() の出力に含まれていない' );
+	}
+
+	/**
+	 * 保存済みの $instance を渡した際に、その値が form() の出力に反映されることを確認する
+	 *
+	 * 既存ユーザーの設定値が正しくフォームに表示されることを検証する。
+	 */
+	public function test_form_with_existing_instance_reflects_saved_values() {
+		// 保存済み設定を模倣した $instance
+		$instance = array(
+			'label'     => 'お知らせ',
+			'count'     => 3,
+			'format'    => '0',
+			'post_type' => 'news',
+			'terms'     => '',
+			'more_url'  => '',
+			'more_text' => '',
+		);
+
+		// form() の出力をキャプチャする
+		ob_start();
+		$this->widget->form( $instance );
+		$output = ob_get_clean();
+
+		// 保存済みの件数 3 が input の value に含まれることを確認する
+		$this->assertStringContainsString( 'value="3"', $output, '保存済みの表示件数（3）が form() の出力に反映されていない' );
+
+		// 保存済みの投稿タイプ news が input の value に含まれることを確認する
+		$this->assertStringContainsString( 'value="news"', $output, '保存済みの投稿タイプ（news）が form() の出力に反映されていない' );
+	}
+}

--- a/_g3/functions.php
+++ b/_g3/functions.php
@@ -344,7 +344,7 @@ add_filter( 'lightning_localize_options', 'lightning_global_nav_fix', 10, 1 );
  * @return array $classes : class list.
  */
 function lightning_add_anchor_nav_class( $classes, $item ) {
-	if ( strpos( $item->url, '#' ) !== false ) {
+	if ( ! empty( $item->url ) && strpos( $item->url, '#' ) !== false ) {
 		$classes[] = 'menu-item-anchor';
 	}
 	return $classes;

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ Bug Fix ] Fixed PHP 8.1 deprecated warning caused by passing null to strpos() when nav menu item URL is null
+
 v15.37.1
 [ Other ] Change theme screenshot
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,8 +35,6 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
-[ G2 ][ Bug Fix ] Fix PHP 8.0+ warning logged when adding Content Area Posts Widget for the first time before saving
-
 v15.37.1
 [ Other ] Change theme screenshot
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G2 ][ Bug Fix ] Fix PHP 8.0+ warning logged when adding Content Area Posts Widget for the first time before saving
+
 v15.37.1
 [ Other ] Change theme screenshot
 


### PR DESCRIPTION
## 関連Issue

- 関連Issue: なし（vektor-inc/multi-repo-tasks#23 のテーマ横断 PHP8 審査で検出）

## 変更の目的・理由

PHP 8.1 以降、`strpos()` に null を渡すと Deprecated 警告が記録されます。
`_g3/functions.php` の `lightning_add_anchor_nav_class()` で、URL 未設定のナビメニューアイテム（ラベルのみ・空URL のカスタムリンク等）が存在する場合に `$item->url` が null となり、警告が発生していました。

## 実装内容

### 主な変更点
- [x] バグ修正

### 技術的な詳細

`_g3/functions.php:347` の条件式に `! empty( $item->url )` の事前ガードを追加。

```php
// 修正前
if ( strpos( $item->url, '#' ) !== false ) {

// 修正後
if ( ! empty( $item->url ) && strpos( $item->url, '#' ) !== false ) {
```

また `_g2/tests/test-widget-new-posts.php` に Content Area Posts Widget の `form()` が空の `$instance` を受け取っても警告を出さないことを検証するテストを追加しています（既存の `wp_parse_args()` による挙動を保証）。

## スクリーンショット

UIへの変更なし。省略。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み
- [ ] 既存のテストが通ることを確認（CI で確認）
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

**Before（修正前の再現手順）**

1. `wp-config.php` に `define( 'WP_DEBUG', true );` と `define( 'WP_DEBUG_LOG', true );` を追加する
2. 管理画面 → 外観 → メニュー で、URL を空にしたカスタムリンク（ラベルのみ）を追加して保存する
3. フロントページを表示する
4. `wp-content/debug.log` を確認する
   → `PHP Deprecated: strpos(): Passing null to parameter #1` の警告が記録される

**After（修正後の確認手順）**

1. 同じメニュー構成のまま修正後のコードを適用する
2. フロントページを表示する
3. `wp-content/debug.log` を確認する
   → 上記の Deprecated 警告が記録されないことを確認

**デグレ確認**

4. `#` を含む URL（例: `#section`）を持つメニューアイテムを追加する
5. フロントページのナビメニューを確認する
   → `menu-item-anchor` クラスが付与されていることを確認

### レビューポイント（任意）

- `! empty()` によるガードが `strpos()` の null 対応として適切か

### 動作確認時の注意事項

- [x] 最新のコードをプルしている
- [ ] ビルドを実行している（JS/CSS ビルド対象ファイルの変更なし）
- [x] 正しいディレクトリで作業している
- [ ] `npm install`を実行している（不要）
- [ ] `composer install`を実行している（不要）
- [x] キャッシュをクリアしている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PHP 8.1 環境で、ナビゲーション項目のURLが未設定/空のときに発生していた非推奨警告を抑制しました。
  * ウィジェット設定画面で、空の初期値でも警告が出にくくなり、初期値/保存済み値がフォームに正しく反映されます。
* **Tests**
  * 新規ウィジェット設定フォームの警告有無、初期値反映、保存済み値反映を検証するテストを追加しました。
* **Documentation**
  * 変更内容を更新履歴に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->