### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - master
       - develop
+    types: [opened, reopened, labeled, synchronize]
 jobs:
   php_unit:
     name: php unittest
+    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## 概要

GitHub Actions の消費削減のため、PHPUnit テストの実行タイミングを見直しました。PR は `run-ci` ラベル付きのときだけテストを実行するように変更します（リリース時のテストは従来どおり維持）。

## 変更内容

- `.github/workflows/build_check.yml`
  - このワークフローは元々 push トリガーを持たず `pull_request` のみでした。
  - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加。
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加し、`run-ci` ラベル付き PR のときのみ実行するように変更。

## 確認手順

1. ラベルなしの PR ではワークフロー（ジョブ）が起動しないこと。
2. `run-ci` ラベルを付与すると起動すること。
3. ブランチへの push だけでは起動しないこと（元々 push トリガーなし）。
4. リリース時は従来どおりテストが実行されること。

CI 設定のみの変更であり、テーマの動作に影響はありません。

関連: vektor-inc/multi-repo-tasks#24
