### PR TITLE
[ 仕様変更 ] font-awesome-versions を 0.7.4 から 0.7.5 に更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	],
 	"require": {
 		"vektor-inc/vk-swiper": "^0.3.5",
-		"vektor-inc/font-awesome-versions": "^0.7.4",
+		"vektor-inc/font-awesome-versions": "^0.7.5",
 		"vektor-inc/vk-color-palette-manager": "^0.4.0",
 		"vektor-inc/vk-breadcrumb": "^0.2.8",
 		"vektor-inc/vk-css-optimize": "^0.2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef2616a52684110b1da6879b0edf521a",
+    "content-hash": "326d4972d0cd49e19fa99181f4d4fbd7",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.4",
+            "version": "0.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa"
+                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
-                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/0f13392629e0af4b6595c5dca59c65d9e854780c",
+                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.4"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.5"
             },
-            "time": "2026-06-26T02:51:54+00:00"
+            "time": "2026-07-08T05:37:47+00:00"
         },
         {
             "name": "vektor-inc/tgm-plugin-activation",

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5
+
 v15.37.1
 [ Other ] Change theme screenshot
 


### PR DESCRIPTION
## 概要

Composer 依存ライブラリ `vektor-inc/font-awesome-versions` を `0.7.4` から `0.7.5` に更新します。

0.7.5 には「旧 Font Awesome バージョン設定が残存していると Fatal Error で画面全体が表示不能になる不具合」の修正が含まれます。これを必須要件とするため、`composer.json` の制約も `^0.7.4` → `^0.7.5` に引き上げています。

### 変更内容
- `composer.json`: 制約を `^0.7.4` → `^0.7.5`
- `composer.lock`: `vektor-inc/font-awesome-versions` を `0.7.5` に更新
- `readme.txt`: Changelog に更新を追記

## 確認手順

1. このブランチをチェックアウトし、`composer install` を実行する
   → エラーなく完了する
2. `composer show vektor-inc/font-awesome-versions | grep versions`
   → `versions : 0.7.5` と表示される
3. Font Awesome の旧バージョン設定（`vk_font_awesome_version` 等）が残っている環境でフロント／管理画面を表示する
   → Fatal Error が発生せず、画面が正常に表示される（0.7.5 の修正が効いていること）

UI・表示上の変更はないためスクリーンショットは省略します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存ライブラリのバージョンを更新しました。
  * リリースノートに、関連する更新内容を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->