### PR TITLE
[ 不具合修正 ] 全幅見出しウィジェット（G2）で文字の影のチェックを外して保存するとPHP 8以降で未定義キー警告が記録される不具合を修正

### DIFF
--- a/_g2/inc/widgets/widget-full-wide-title.php
+++ b/_g2/inc/widgets/widget-full-wide-title.php
@@ -169,7 +169,7 @@ class LTG_Theme_Full_Wide_Title extends WP_Widget {
 		$instance['title_font_color']   = sanitize_hex_color( $new_instance['title_font_color'] );
 		$instance['title']              = wp_kses_post( $new_instance['title'] );
 		$instance['text']               = wp_kses_post( $new_instance['text'] );
-		$instance['title_shadow_use']   = ( $new_instance['title_shadow_use'] ) ? true : false;
+		$instance['title_shadow_use']   = ( ! empty( $new_instance['title_shadow_use'] ) ) ? true : false;
 		$instance['title_shadow_color'] = sanitize_hex_color( $new_instance['title_shadow_color'] );
 		$instance['margin_top']         = esc_attr( $new_instance['margin_top'] );
 		$instance['margin_bottom']      = esc_attr( $new_instance['margin_bottom'] );

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G2 ][ Bug Fix ] Fix undefined array key warning logged on PHP 8 or later when saving the Full Wide Title widget with the text shadow checkbox unchecked
+
 v15.37.1
 [ Other ] Change theme screenshot
 


### PR DESCRIPTION
## 関連Issue
- 関連Issue: vektor-inc/multi-repo-tasks#23

## 変更の目的・理由
全幅見出しウィジェット（Full Wide Title・G2 構成）の保存処理 `update()` が、チェックボックス「文字の影を使用する」の値を `isset` 無しで直接参照しているため、チェックを外して保存すると送信されないキーを読み、PHP 8.0 以降で `Undefined array key "title_shadow_use"` 警告がエラーログに記録される。ウィジェット保存のたびに発生するため防御的に修正する。（当ウィジェットは G2 構成のみに存在し、G3 には無い）

## 実装内容
`_g2/inc/widgets/widget-full-wide-title.php` の `update()` 内、`title_shadow_use` の参照を `! empty()` でガード。

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細
- 原因: 未チェックのチェックボックスは POST に含まれないため、`$new_instance['title_shadow_use']` が未定義キー参照になる。
- 対策: `( ! empty( $new_instance['title_shadow_use'] ) ) ? true : false` に変更。未定義・空・falsy はすべて false、値ありは true となり、**修正前後で保存値・表示は完全に不変**（出力不変の防御的修正）。

## スクリーンショット
純粋な保存ロジックの修正で UI・フロント表示に変化がないため省略。

### Before（変更前）
（表示変更なし）

### After（変更後）
（表示変更なし）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み（本テーマにウィジェット向け PHPUnit ハーネスが無いため未実装。代わりに PHP 8.4.7 の再現ハーネスで警告発生 → 消滅を実証。下記テスト手順参照）
- [x] 既存のテストが通ることを確認（CI は `run-ci` ラベル付与時のみ実行のため未実施）
- [x] 手動テストを実施済み（PHP 8.4.7 で修正前=警告1件 / 修正後=0件を確認）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
対象テーマ **Lightning（G2 構成）** を有効化し、`WP_DEBUG` 有効・PHP 8.0 以降の環境で確認する。

Before（修正前 / master）
1. 「外観 > ウィジェット」で「全幅見出し（Full Wide Title）」ウィジェットをウィジェットエリアに追加する → 設定フォームが表示される
2. 「文字の影を使用する」の**チェックを外して**保存する → `wp-content/debug.log` に `Undefined array key "title_shadow_use" in .../_g2/inc/widgets/widget-full-wide-title.php on line 172` が記録される

After（修正後 / 本ブランチ）
3. 同じ操作（チェックを外して保存）を行う → 上記警告が記録されない
4. 「文字の影」チェックあり＝影あり／チェックなし＝影なし が修正前と同一であることを確認する → 保存値・フロント表示に変化なし（デグレなし）

### レビューポイント（任意）
- `update()` は最終的に `return $new_instance;` を返す構造（本PRスコープ外・別途 #23 側で扱いを検討）。今回の172行の変更は右辺の読み取り警告を除去するのみで保存出力を変えない。

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
- 当ウィジェットは G2 構成のみに存在し、G3 には無い。現行 Lightning（G3）環境では読み込まれないため、確認は G2 構成で行う必要がある。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * PHP 8以降で「Full Wide Title」ウィジェットを保存する際、テキストシャドウのチェックボックスが未選択の場合に発生する警告を修正しました。
  * チェックボックスの設定が未選択時に正しく無効として保存されるようになりました。

* **ドキュメント**
  * 修正内容を変更履歴に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->