### PR TITLE
[ 不具合修正 ][ 全幅見出し ] ブロック版ウィジェット編集画面でPHP警告が記録される不具合を修正

### DIFF
--- a/_g2/inc/widgets/widget-full-wide-title.php
+++ b/_g2/inc/widgets/widget-full-wide-title.php
@@ -251,7 +251,9 @@ class LTG_Theme_Full_Wide_Title extends WP_Widget {
 			$widget_outer_style .= 'margin-bottom:0px;background-repeat:no-repeat;';
 		}
 
-		if ( $widget_outer_style ) {
+		// ブロック版ウィジェット編集画面のプレビューでは widget_id が $args に含まれず渡ってくるため、
+		// 未設定の場合はインラインCSSの出力をスキップして PHP の Undefined array key 警告を防ぐ。
+		if ( $widget_outer_style && ! empty( $args['widget_id'] ) ) {
 			$dynamic_css = '#' . $args['widget_id'] . '.widget {' . $widget_outer_style . '}';
 			// $dynamic_css = trim( $dynamic_css );
 			// // convert tab and br to space

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ vk-develop@vektor-inc.co.jp
 == Changelog ==
 
 [ G2 ][ Bug Fix ] Fix undefined array key warning logged on PHP 8 or later when saving the Full Wide Title widget with the text shadow checkbox unchecked
+[ G2 ][ Bug Fix ] Fix undefined array key warning logged on PHP 8 or later when displaying the Full Wide Title widget in the block-based widget editor preview
 
 v15.37.1
 [ Other ] Change theme screenshot


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #1366
- 関連Issue: vektor-inc/multi-repo-tasks#23

## 変更の目的・理由
全幅見出しウィジェット（G2 構成）の描画処理 `widget()` が `$args['widget_id']` を未ガードで参照しているため、ブロック版ウィジェット編集画面（外観 > ウィジェット）のプレビュー描画で `Undefined array key "widget_id"` 警告がエラーログに記録される。通常のフロント表示（`dynamic_sidebar()` 経由）では `widget_id` が渡るため不発。警告を解消する防御的修正。

## 実装内容
`_g2/inc/widgets/widget-full-wide-title.php` の `widget()` 内、インライン CSS 出力条件に `! empty( $args['widget_id'] )` ガードを追加。未設定時は当該 CSS 出力をスキップする。

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細
- 原因: ブロック版ウィジェット編集画面のプレビューでは `$args` に `widget_id` が含まれない
- 対策: `widget_id` が空の場合はインライン CSS の組み立て・出力をスキップ
- 通常フロント（`widget_id` あり）の出力は修正前後で不変

## スクリーンショット
純粋な警告抑制の修正で UI・フロント表示に変化がないため省略。

### Before（変更前）
（表示変更なし）

### After（変更後）
（表示変更なし）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み（本テーマにウィジェット向け PHPUnit ハーネスが無いため未実装。代わりに PHP 8.2 の再現ハーネスで警告発生 → 消滅を実証）
- [x] 既存のテストが通ることを確認（CI は `run-ci` ラベル付与時のみ実行のため未実施）
- [x] 手動テストを実施済み（PHP 8.2 で修正前=警告1件 / 修正後=0件、`widget_id` あり時のインラインCSSは不変を確認）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
対象テーマ **Lightning（G2 構成）** を有効化し、`WP_DEBUG` 有効・PHP 8.0 以降の環境で確認する。

Before（修正前 / master）
1. 「外観 > ウィジェット」で「全幅見出し（Full Wide Title）」ウィジェットをウィジェットエリアに追加する
2. マージン上下など、インライン CSS が出力される条件になる設定を入れる
3. → `wp-content/debug.log` に `Undefined array key "widget_id" in .../_g2/inc/widgets/widget-full-wide-title.php` が記録される

After（修正後 / 本ブランチ）
4. 同じ操作を行う → 上記警告が記録されない
5. フロント（通常のサイドバー表示）で `widget_id` ありの描画時、マージン用インライン CSS が従来どおり出力されることを確認する → デグレなし

### レビューポイント（任意）
- 当ウィジェットは G2 構成のみに存在し、G3 には無い
- 同ウィジェットの保存時警告（`title_shadow_use`）は #1365 で別対応済み

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
- 確認は G2 構成で行う必要がある（G3 では当該ウィジェットが読み込まれない）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ブロックエディターのウィジェット編集プレビューで、Full Wide Titleウィジェット表示時にPHP 8以降で発生する未定義配列キー警告を修正しました。
  * 該当環境で不要なインラインCSSの出力を抑制しました。

* **Documentation**
  * 上記の修正内容を変更履歴に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->