### PR TITLE
[ 不具合修正 ][ G2 ] ブロック版ウィジェット編集画面で全幅見出しウィジェットの画像設定ボタンが機能しない問題を修正

### DIFF
--- a/_g2/assets/js/admin-widget.js
+++ b/_g2/assets/js/admin-widget.js
@@ -1,0 +1,29 @@
+/* global jQuery, wp */
+/**
+ * 背景画像登録処理
+ *
+ * @param {HTMLElement} e ボタン要素
+ */
+window.vk_title_bg_image_addiditional = function( e ) {
+	var d = jQuery( e ).parent().children( '._display' );
+	var w = jQuery( e ).parent().children( '._form' ).children( '.__id' )[ 0 ];
+	var u = wp.media( { library: { type: 'image' }, multiple: false } ).on( 'select', function() {
+		u.state().get( 'selection' ).each( function( f ) {
+			d.children().remove();
+			d.append( jQuery( '<img style="width:100%;height:auto">' ).attr( 'src', f.toJSON().url ) );
+			jQuery( w ).val( f.toJSON().id ).change();
+		} );
+	} );
+	u.open();
+};
+
+/**
+ * 背景画像削除処理
+ *
+ * @param {HTMLElement} e ボタン要素
+ */
+window.vk_title_bg_image_delete = function( e ) {
+	var d = jQuery( e ).parent().children( '._display' );
+	d.children().remove();
+	jQuery( e ).parent().children( '._form' ).children( '.__id' ).attr( 'value', '' ).change();
+};

--- a/_g2/assets/js/admin-widget.js
+++ b/_g2/assets/js/admin-widget.js
@@ -1,8 +1,8 @@
 /* global jQuery, wp */
 /**
- * 背景画像登録処理
+ * Open the media library and set the selected image as background. / 背景画像登録処理
  *
- * @param {HTMLElement} e ボタン要素
+ * @param {HTMLElement} e Button element. / ボタン要素
  */
 window.vk_title_bg_image_addiditional = function( e ) {
 	var d = jQuery( e ).parent().children( '._display' );
@@ -18,9 +18,9 @@ window.vk_title_bg_image_addiditional = function( e ) {
 };
 
 /**
- * 背景画像削除処理
+ * Remove the background image. / 背景画像削除処理
  *
- * @param {HTMLElement} e ボタン要素
+ * @param {HTMLElement} e Button element. / ボタン要素
  */
 window.vk_title_bg_image_delete = function( e ) {
 	var d = jQuery( e ).parent().children( '._display' );

--- a/_g2/inc/widgets/widget-full-wide-title.php
+++ b/_g2/inc/widgets/widget-full-wide-title.php
@@ -265,7 +265,7 @@ function ltg_full_wide_title_admin_enqueue( $hook ) {
 	wp_enqueue_media();
 	wp_enqueue_script(
 		'ltg-widget-image-admin',
-		get_template_directory_uri() . '/_g2/assets/js/admin-widget.js',
+		get_template_directory_uri() . '/assets/js/admin-widget.js',
 		array( 'jquery' ),
 		'1.0.0',
 		true

--- a/_g2/inc/widgets/widget-full-wide-title.php
+++ b/_g2/inc/widgets/widget-full-wide-title.php
@@ -100,40 +100,6 @@ class LTG_Theme_Full_Wide_Title extends WP_Widget {
 				<input type="hidden" class="__id" name="<?php echo $this->get_field_name( 'media_image_id' ); ?>" value="<?php echo esc_attr( $options['media_image_id'] ); ?>" />
 			</div>
 		</div>
-		<script type="text/javascript">
-			// Register background image
-			if ( vk_title_bg_image_addiditional == undefined ){
-				var vk_title_bg_image_addiditional = function(e){
-					// Preview area div
-					var d=jQuery(e).parent().children("._display");
-					// Input tag of save image id.
-					var w=jQuery(e).parent().children("._form").children('.__id')[0];
-					var u=wp.media({library:{type:'image'},multiple:false}).on('select', function(e){
-						u.state().get('selection').each(function(f){
-							d.children().remove();
-							d.append(jQuery('<img style="width:100%;mheight:auto">').attr('src',f.toJSON().url));
-							jQuery(w).val(f.toJSON().id).change();
-						});
-					});
-					u.open();
-				};
-			}
-			// Function of Delete background image
-			if ( vk_title_bg_image_delete == undefined ){
-				var vk_title_bg_image_delete = function(e){
-					// Preview area div
-					var d=jQuery(e).parent().children("._display");
-						// Input tag of save image id.
-					var w=jQuery(e).parent().children("._form").children('.__id')[0];
-
-					// Delete tag of preview img.
-					d.children().remove();
-					// w.attr("value","");
-					jQuery(e).parent().children("._form").children('.__id').attr("value","").change();
-				};
-			}
-		</script>
-
 		<?php
 
 		// Shadow Use
@@ -284,4 +250,24 @@ class LTG_Theme_Full_Wide_Title extends WP_Widget {
 add_action( 'widgets_init', 'lightning_unit_widget_register_full_wide_title' );
 function lightning_unit_widget_register_full_wide_title() {
 	return register_widget( 'LTG_Theme_Full_Wide_Title' );
+}
+
+add_action( 'admin_enqueue_scripts', 'ltg_full_wide_title_admin_enqueue' );
+/**
+ * ウィジェット管理画面でメディアライブラリ用スクリプトを読み込む
+ *
+ * @param string $hook 現在の管理画面のフック名。
+ */
+function ltg_full_wide_title_admin_enqueue( $hook ) {
+	if ( ! in_array( $hook, array( 'widgets.php', 'customize.php' ), true ) ) {
+		return;
+	}
+	wp_enqueue_media();
+	wp_enqueue_script(
+		'ltg-widget-image-admin',
+		get_template_directory_uri() . '/_g2/assets/js/admin-widget.js',
+		array( 'jquery' ),
+		'1.0.0',
+		true
+	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ G2 ][ Bug Fix ] Fix image set/delete buttons in the Full Wide Title widget not opening the media library in the block-based widget editor
+
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.4 to 0.7.5
 [ G2 ][ Bug Fix ] Fix undefined array key warning logged on PHP 8 or later when saving the Full Wide Title widget with the text shadow checkbox unchecked
 [ G2 ][ Bug Fix ] Fix undefined array key warning logged on PHP 8 or later when displaying the Full Wide Title widget in the block-based widget editor preview


### PR DESCRIPTION
## 関連Issue
- 関連Issue: https://github.com/vektor-inc/multi-repo-tasks/issues/28


## 変更の目的・理由

ブロック版ウィジェット編集画面（外観 > ウィジェット）で、全幅見出しウィジェット（Full Wide Title widget）の「背景画像を設定」「背景画像を削除」ボタンをクリックしてもメディアライブラリが開かない不具合を修正します。

ウィジェットの `form()` メソッドが HTML 内にインライン `<script>` タグでJS関数を定義していたため、ブロック版ウィジェット編集画面が動的にフォーム HTML を挿入する際にインラインスクリプトが実行されず、`ReferenceError: vk_title_bg_image_addiditional is not defined` が発生していました。

## 実装内容

### 主な変更点
- [x] バグ修正

### 技術的な詳細

- `_g2/inc/widgets/widget-full-wide-title.php` の `form()` メソッド内のインライン `<script>` タグを削除
- 同ファイルに `admin_enqueue_scripts` フック（`ltg_full_wide_title_admin_enqueue()`）を追加し、`widgets.php` / `customize.php` 画面のみで `wp_enqueue_media()` と外部JSファイルを読み込むように変更
- `_g2/assets/js/admin-widget.js` を新規作成し、`vk_title_bg_image_addiditional`（背景画像登録処理）と `vk_title_bg_image_delete`（背景画像削除処理）をグローバル関数として定義

## スクリーンショット
（UI変更なし・動作のみの修正のため省略）

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [ ] 書けるテストは実装済み（JS の動的挿入挙動はブラウザ環境依存のため PHPUnit/Playwright では対象外）
- [ ] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順

#### Before（修正前の再現手順）

1. WordPress 管理画面で「外観 > ウィジェット」を開く
2. 「G2 全幅見出し (Full Wide Title)」ウィジェットを任意のウィジェットエリアに追加する
3. ウィジェット設定内の「Set image」ボタンをクリックする
4. → メディアライブラリが開かない（ブラウザコンソールに `ReferenceError: vk_title_bg_image_addiditional is not defined` が出力される）

#### After（修正後の期待動作）

1. 同じ手順でウィジェットを追加する
2. 「Set image」ボタンをクリックする
3. → メディアライブラリが開き、画像を選択・設定できる
4. 「Delete image」ボタンをクリックする
5. → 設定した画像が削除される

#### 既存ユーザーへの影響確認

6. 修正前にウィジェットに画像を保存済みの環境でも、保存済みの画像IDが正常に表示・削除できることを確認する

### レビューポイント（任意）
- `ltg_full_wide_title_admin_enqueue()` のフック登録が `widgets.php` / `customize.php` 以外で発火しないこと

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブロックベースのウィジェットエディターで、Full Wide Titleウィジェットの画像設定ボタンからメディアライブラリを開けない問題を修正しました。
  * メディアライブラリから選択した画像を背景画像として設定し、プレビューに表示できるようになりました。
  * 設定済みの背景画像を削除できるようになりました。

* **管理画面**
  * ウィジェット編集画面およびカスタマイザーで、画像選択機能を利用できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->