### PR TITLE
[ 開発環境 ] テスト実行で theme.json が消えてテーマ設定が失われる問題を修正

### DIFF
--- a/_g2/tests/bootstrap.php
+++ b/_g2/tests/bootstrap.php
@@ -2,6 +2,9 @@
 // Require composer dependencies.
 require_once dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php';
 
+// テスト実行で theme.json のファイル名が変わったまま残らないようにする.
+require_once dirname( __DIR__, 2 ) . '/tests/theme-json-guard.php';
+
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );

--- a/_g3/tests/bootstrap.php
+++ b/_g3/tests/bootstrap.php
@@ -2,6 +2,9 @@
 // Require composer dependencies.
 require_once dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php';
 
+// テスト実行で theme.json のファイル名が変わったまま残らないようにする.
+require_once dirname( __DIR__, 2 ) . '/tests/theme-json-guard.php';
+
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );

--- a/phpunit.g2.xml
+++ b/phpunit.g2.xml
@@ -8,7 +8,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="test-targets">
 			<directory prefix="test-" suffix=".php">./vendor/vektor-inc/vk-wp-unit-test-tools/src/tests/</directory>
 			<directory prefix="test-" suffix=".php">./_g2/tests/</directory>
 			<exclude>./tests/test-sample.php</exclude>

--- a/phpunit.g3.xml
+++ b/phpunit.g3.xml
@@ -8,7 +8,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="test-targets">
 			<directory prefix="test-" suffix=".php">./vendor/vektor-inc/vk-wp-unit-test-tools/src/tests/</directory>
 			<directory prefix="test-" suffix=".php">./_g3/tests/</directory>
 		</testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,9 @@
 // Require composer dependencies.
 require_once dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
+// テスト実行で theme.json のファイル名が変わったまま残らないようにする.
+require_once dirname( __DIR__ ) . '/tests/theme-json-guard.php';
+
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
 require_once dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
 // テスト実行で theme.json のファイル名が変わったまま残らないようにする.
-require_once dirname( __DIR__ ) . '/tests/theme-json-guard.php';
+require_once __DIR__ . '/theme-json-guard.php';
 
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {

--- a/tests/test-ltg_theme_json_activator.php
+++ b/tests/test-ltg_theme_json_activator.php
@@ -11,15 +11,68 @@
 class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 
 	/**
-	 * Reset theme json
-	 * テーマの theme.json は初期状態では _theme.json でなくてはならない。
-	 * テストの過程で theme.json に変更された場合、テスト後に _theme.json に戻す
+	 * テスト開始前のファイル名（theme.json / _theme.json のどちらか）
+	 * テスト終了後はこのファイル名に必ず戻す
+	 *
+	 * @var string
+	 */
+	private static $original_theme_json_file_name = '';
+
+	/**
+	 * テストクラス実行前にファイル名の初期状態を記録する
 	 *
 	 * @return void
 	 */
-	public static function reset_theme_json() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		// 初期状態のファイル名を記録しておき、tear_down() でこの状態に戻す.
+		self::$original_theme_json_file_name = self::detect_theme_json_file_name();
+	}
+
+	/**
+	 * 各テスト終了後にファイル名を初期状態へ戻す
+	 * アサーション失敗や例外で途中終了した場合も PHPUnit が必ず呼ぶため、
+	 * リポジトリの状態が壊れたまま残らない
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		self::restore_theme_json();
+		parent::tear_down();
+	}
+
+	/**
+	 * 現在存在している theme.json 系ファイルの名前を取得する
+	 *
+	 * ファイル名の一覧と検出・復元のアルゴリズムは tests/theme-json-guard.php に
+	 * 一本化してある。ここで再実装すると、ファイル名を変えたときに片方だけ直して
+	 * 乖離するため、必ず委譲すること。
+	 *
+	 * @return string : 見つかったファイル名。見つからない場合は空文字.
+	 */
+	private static function detect_theme_json_file_name() {
+		return ltg_test_detect_theme_json_file_name( get_template_directory() );
+	}
+
+	/**
+	 * theme.json のファイル名をテスト開始前の状態に戻す
+	 *
+	 * @return void
+	 */
+	private static function restore_theme_json() {
+		ltg_test_restore_theme_json_file_name( get_template_directory(), self::$original_theme_json_file_name );
+	}
+
+	/**
+	 * theme.json を無効化状態（_theme.json）にする
+	 * 「ファイルが存在しない場合」のテストの前準備として、
+	 * 意図的にファイル名を _theme.json へ切り替えるために使う（後片付け用ではない）
+	 *
+	 * @return void
+	 */
+	private static function deactivate_theme_json_file() {
 		if ( is_readable( get_template_directory() . '/theme.json' ) ) {
-			$file_before = rename( get_template_directory() . '/theme.json', get_template_directory() . '/_theme.json' );
+			rename( get_template_directory() . '/theme.json', get_template_directory() . '/_theme.json' );
 		}
 	}
 
@@ -65,7 +118,6 @@ class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 		print '------------------------------------' . PHP_EOL;
 
 		foreach ( $test_array as $key => $value ) {
-
 			if ( ! empty( $value['lightning_theme_options'] ) ) {
 				update_option( 'lightning_theme_options', $value['lightning_theme_options'] );
 			} else {
@@ -89,7 +141,8 @@ class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 			$this->assertEquals( $expected_rename, $actual );
 		}
 
-		self::reset_theme_json();
+		// 次のテストの前準備として、意図的に無効化状態（_theme.json）にする.
+		self::deactivate_theme_json_file();
 
 		/*******************************************
 		 * Lightningの中に theme.json 用のファイルがない場合のテスト
@@ -104,8 +157,7 @@ class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 			$rename = rename( get_template_directory() . '/no_theme.json', get_template_directory() . '/_theme.json' );
 		}
 
-		self::reset_theme_json();
-
+		// 後片付けは tear_down() の restore_theme_json() が行う.
 	}
 
 	/**
@@ -161,7 +213,7 @@ class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 			}
 
 			if ( ! is_readable( $file_before ) ) {
-				$file_before = rename( $file_need_rename, $file_before );
+				rename( $file_need_rename, $file_before );
 			}
 
 			// Do update option.
@@ -171,8 +223,7 @@ class LTG_Theme_Json_Activator_Test extends WP_UnitTestCase {
 
 			$actual = is_readable( get_template_directory() . '/' . $value['expacted'] );
 			$this->assertTrue( $actual );
-
 		}
-		self::reset_theme_json();
+		// 後片付けは tear_down() の restore_theme_json() が行う.
 	}
 }

--- a/tests/theme-json-guard.php
+++ b/tests/theme-json-guard.php
@@ -83,7 +83,16 @@ if ( ! function_exists( 'ltg_test_restore_theme_json_file_name' ) ) {
 
 		// リネームに失敗した場合に戻す前のファイル名を返すと、実際には戻せていないのに
 		// 「戻しました」と警告が出て事実と食い違うため、成功したときだけ返す.
+		// ただし無言で返すと復元できていないことに誰も気付けないため、
+		// 失敗したこと自体は STDERR に出す（戻せていない＝最も危険な状態のため）.
 		if ( ! rename( $theme_dir . '/' . $current_file_name, $original_path ) ) {
+			if ( defined( 'STDERR' ) ) {
+				fwrite(
+					STDERR,
+					PHP_EOL . '[theme-json-guard] ' . $current_file_name . ' を ' . $original_file_name
+						. ' に戻せませんでした。リポジトリの状態が変わったままなので手動で戻してください。' . PHP_EOL
+				);
+			}
 			return '';
 		}
 		return $current_file_name;

--- a/tests/theme-json-guard.php
+++ b/tests/theme-json-guard.php
@@ -85,14 +85,14 @@ if ( ! function_exists( 'ltg_test_restore_theme_json_file_name' ) ) {
 		// 「戻しました」と警告が出て事実と食い違うため、成功したときだけ返す.
 		// ただし無言で返すと復元できていないことに誰も気付けないため、
 		// 失敗したこと自体は STDERR に出す（戻せていない＝最も危険な状態のため）.
+		// STDERR は冒頭の SAPI 判定を通過した時点で必ず定義されているため、
+		// 下の shutdown 側と同じくガードせずにそのまま使う.
 		if ( ! rename( $theme_dir . '/' . $current_file_name, $original_path ) ) {
-			if ( defined( 'STDERR' ) ) {
-				fwrite(
-					STDERR,
-					PHP_EOL . '[theme-json-guard] ' . $current_file_name . ' を ' . $original_file_name
-						. ' に戻せませんでした。リポジトリの状態が変わったままなので手動で戻してください。' . PHP_EOL
-				);
-			}
+			fwrite(
+				STDERR,
+				PHP_EOL . '[theme-json-guard] ' . $current_file_name . ' を ' . $original_file_name
+					. ' に戻せませんでした。リポジトリの状態が変わったままなので手動で戻してください。' . PHP_EOL
+			);
 			return '';
 		}
 		return $current_file_name;

--- a/tests/theme-json-guard.php
+++ b/tests/theme-json-guard.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * テスト実行で theme.json のファイル名が変わったまま残るのを防ぐガード
+ *
+ * LTG_Theme_Json_Activator は 'updated_option' フックで theme.json と _theme.json を
+ * リネームするため、テスト中に lightning_theme_options を更新すると副作用で
+ * ファイル名が変わる。リポジトリが追跡しているのは theme.json なので、
+ * そのままだとテストを実行しただけで theme.json が消えた状態になってしまう。
+ *
+ * ここでテスト開始時点のファイル名を記録し、PHPUnit 終了時に必ず元の状態へ戻す。
+ *
+ * @package vektor-inc/lightning
+ */
+
+// このファイルはリリース zip の tests/ にも同梱され、公開サイト上で URL から
+// 直接叩ける位置に置かれる。読み込むだけでファイル操作を登録するため、
+// CLI（PHPUnit）以外では何もせずに終了する.
+if ( 'cli' !== PHP_SAPI && 'phpdbg' !== PHP_SAPI ) {
+	return;
+}
+
+if ( ! function_exists( 'ltg_test_theme_json_file_names' ) ) {
+	/**
+	 * テストの過程で存在し得る theme.json 系ファイルの名前
+	 *
+	 * リポジトリが追跡しているのは theme.json だが、無効化状態では _theme.json 、
+	 * 「ファイルが無い場合」のテスト中は no_theme.json になる。
+	 *
+	 * この一覧と下記の検出・復元は、テストクラス側
+	 * （tests/test-ltg_theme_json_activator.php）からも呼ばれる。
+	 * 実装を二重に持つとファイル名を変えたときに片方だけ直して乖離するため、
+	 * 必ずここを唯一の定義とすること。
+	 *
+	 * @return string[]
+	 */
+	function ltg_test_theme_json_file_names() {
+		return array( 'theme.json', '_theme.json', 'no_theme.json' );
+	}
+}
+
+if ( ! function_exists( 'ltg_test_detect_theme_json_file_name' ) ) {
+	/**
+	 * 現在存在している theme.json 系ファイルの名前を取得する
+	 *
+	 * @param string $theme_dir テーマのルートディレクトリ.
+	 * @return string 見つかったファイル名。見つからない場合は空文字.
+	 */
+	function ltg_test_detect_theme_json_file_name( $theme_dir ) {
+		foreach ( ltg_test_theme_json_file_names() as $file_name ) {
+			if ( is_readable( $theme_dir . '/' . $file_name ) ) {
+				return $file_name;
+			}
+		}
+		return '';
+	}
+}
+
+if ( ! function_exists( 'ltg_test_restore_theme_json_file_name' ) ) {
+	/**
+	 * theme.json のファイル名を指定された状態へ戻す
+	 *
+	 * @param string $theme_dir          テーマのルートディレクトリ.
+	 * @param string $original_file_name 戻したいファイル名.
+	 * @return string 実際に戻した場合は戻す前のファイル名。何もしなかった場合は空文字.
+	 */
+	function ltg_test_restore_theme_json_file_name( $theme_dir, $original_file_name ) {
+		// 戻し先が分からない場合は誤ってリネームしないよう何もしない.
+		if ( '' === $original_file_name ) {
+			return '';
+		}
+
+		$original_path = $theme_dir . '/' . $original_file_name;
+
+		// すでに戻したい状態なら何もしない.
+		if ( is_readable( $original_path ) ) {
+			return '';
+		}
+
+		$current_file_name = ltg_test_detect_theme_json_file_name( $theme_dir );
+		if ( '' === $current_file_name ) {
+			return '';
+		}
+
+		rename( $theme_dir . '/' . $current_file_name, $original_path );
+		return $current_file_name;
+	}
+}
+
+if ( ! function_exists( 'ltg_test_guard_theme_json_file_name' ) ) {
+	/**
+	 * theme.json のファイル名をテスト開始前の状態へ戻すガードを登録する
+	 *
+	 * @param string $theme_dir テーマのルートディレクトリ.
+	 * @return void
+	 */
+	function ltg_test_guard_theme_json_file_name( $theme_dir ) {
+		// テスト開始時点のファイル名を記録する.
+		$original_file_name = ltg_test_detect_theme_json_file_name( $theme_dir );
+
+		// どれも見つからない場合は誤ってリネームしないよう何もしない.
+		if ( '' === $original_file_name ) {
+			return;
+		}
+
+		// テストが失敗・異常終了した場合でも必ず実行されるよう shutdown 時に復元する.
+		register_shutdown_function(
+			function () use ( $theme_dir, $original_file_name ) {
+				$renamed_from = ltg_test_restore_theme_json_file_name( $theme_dir, $original_file_name );
+
+				// 無言で直すと、別ルートで再発しても誰も気付けなくなる。
+				// 実際に復元したときだけ警告を出す（正常系では何も出ない）.
+				if ( '' !== $renamed_from ) {
+					fwrite(
+						STDERR,
+						PHP_EOL . '[theme-json-guard] ' . $renamed_from . ' を ' . $original_file_name . ' に戻しました。'
+							. 'テスト中に theme.json のファイル名が変わっています。' . PHP_EOL
+					);
+				}
+			}
+		);
+	}
+}
+
+// このファイルは <テーマルート>/tests/ に置かれているため、親ディレクトリがテーマルート.
+ltg_test_guard_theme_json_file_name( dirname( __DIR__ ) );

--- a/tests/theme-json-guard.php
+++ b/tests/theme-json-guard.php
@@ -12,9 +12,9 @@
  * @package vektor-inc/lightning
  */
 
-// このファイルはリリース zip の tests/ にも同梱され、公開サイト上で URL から
-// 直接叩ける位置に置かれる。読み込むだけでファイル操作を登録するため、
-// CLI（PHPUnit）以外では何もせずに終了する.
+// 読み込むだけでファイル操作を登録するため、CLI（PHPUnit）以外では何もせずに終了する。
+// 現状 tests/ は copy-files.js の excludedPaths でリリース zip から除外されており
+// 公開サイトに置かれることはないが、除外設定が変わった場合の保険として残す.
 if ( 'cli' !== PHP_SAPI && 'phpdbg' !== PHP_SAPI ) {
 	return;
 }
@@ -81,7 +81,11 @@ if ( ! function_exists( 'ltg_test_restore_theme_json_file_name' ) ) {
 			return '';
 		}
 
-		rename( $theme_dir . '/' . $current_file_name, $original_path );
+		// リネームに失敗した場合に戻す前のファイル名を返すと、実際には戻せていないのに
+		// 「戻しました」と警告が出て事実と食い違うため、成功したときだけ返す.
+		if ( ! rename( $theme_dir . '/' . $current_file_name, $original_path ) ) {
+			return '';
+		}
 		return $current_file_name;
 	}
 }


### PR DESCRIPTION
## 概要

**PHPUnit を実行すると作業ツリーの `theme.json` が `_theme.json` に変わったまま残ります。** その状態で `git add -A` した開発者は、`theme.json` を削除したコミットを作ってしまいます。

これがマージされると、更新した全サイトで**テーマのグローバル設定（フォントサイズ・余白のプリセット）がエラーも出さずに失われます**。ユーザーから見れば「更新したら急に見た目が変わった」だけで、原因に到達できません。

実際に分割前の PR でこの事故が起きました（`theme.json` が消えたコミットを push した状態まで進行）。通常の表示確認では誰も気づけませんでした。

## 原因は 2 つありました

**1. 後片付けの前提が実態と逆だった**

`tests/test-ltg_theme_json_activator.php` の後片付けが「テーマの `theme.json` は初期状態では `_theme.json` でなくてはならない」という前提で、**無条件に `theme.json` → `_theme.json` へリネーム**していました。しかしリポジトリが追跡しているのは `theme.json` です。

つまり「後片付け」のつもりの処理が、毎回リポジトリの状態を壊す方向に働いていました。

**2. g2 / g3 側にも別ルートがあった**

`LTG_Theme_Json_Activator` が `updated_option` フックでリネームを実行するため、`update_option( 'lightning_theme_options', ... )` を呼ぶ `_g2/tests/` ・ `_g3/tests/` の複数のテスト（`test-lightning_get_theme_options.php`、`test-vk-breadcrumb.php`、`test-ltg-g3-slider-preload.php` 等）が**副作用でリネームを誘発**していました。

`tests/` だけ直しても g2 / g3 で再発し続ける状態でした。

## 対応

**実行開始時のファイル名を記録し、必ずその状態へ戻す**形に変えます。`theme.json` 始まり・`_theme.json` 始まりのどちらでも壊さないことが要件です。

- **`tests/theme-json-guard.php` を追加** — 3 つの bootstrap から読み込み、`register_shutdown_function()` で PHPUnit 終了時に復元
- **テストクラス側は `set_up_before_class()` で記録し `tear_down()` で復元** — アサーション失敗や例外で途中終了しても PHPUnit が必ず呼ぶため
- **ファイル名一覧と検出・復元処理をガード側の共通ヘルパーに集約** — 二重実装だとファイル名変更時に片方だけ直して乖離するため
- **復元を実行したときだけ STDERR に警告を出す** — 無言で直すと、別ルートで再発しても誰も気付けません。正常系では無出力です
- **ガードは CLI 以外では即座に `return`** — 読み込むだけでファイル操作を登録するため、CLI 以外での実行を止めます。なお `tests/` は `copy-files.js` の `excludedPaths` によりリリース zip から除外されており、現状は公開サイトに置かれません（当初「リリース zip に同梱される」と書いていましたが、レビューでの実測により誤りと判明したため訂正しました）。除外設定が変わった場合の保険として CLI 判定は残しています
- **`phpunit.g2.xml` / `phpunit.g3.xml` の `<testsuite>` に `name` 属性を追加** — `--filter` 付き実行時の validation 警告を解消

### 後片付けと前準備を役割で分離しました

旧 `reset_theme_json()` は 3 箇所から呼ばれていましたが、**うち 1 箇所は後片付けではなく「ファイルが存在しない場合」のテストの前準備**でした（意図的に無効化状態へ倒すもの）。単純に消すと当該テストが素通りしてしまうため、`deactivate_theme_json_file()` として分離しています。

今回の事故の根っこは「名前と役割の不一致」だったので、ここを分けたのが根治にあたります。

## 確認手順

### 1. 修正前の再現を確認（任意）

```bash
git stash && npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.root.xml
git status --porcelain
```

→ ✓ `D theme.json` / `?? _theme.json` が出る（これが直したい状態）

```bash
git checkout -- theme.json && rm -f _theme.json && git stash pop
```

### 2. 修正後、テスト実行で作業ツリーが汚れないことを確認

```bash
npx wp-env start
for c in phpunit.root.xml phpunit.g2.xml phpunit.g3.xml; do
  npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c $c
done
ls theme.json
git status --porcelain
```

→ ✓ 3 スイートすべて通る
→ ✓ `theme.json` が存在する
→ ✓ `git status` が空（`_theme.json` が残らない）

### 3. `_theme.json` 始まりでも初期状態が保たれることを確認

```bash
git mv theme.json _theme.json
npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.root.xml
ls _theme.json theme.json 2>/dev/null
```

→ ✓ テストが通る
→ ✓ **`_theme.json` のまま**保たれている（`theme.json` は存在しない）

```bash
git mv _theme.json theme.json
```

### 4. validation 警告が消えたことを確認

```bash
npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.g3.xml --filter LTG 2>&1 | grep -c "did not pass validation"
```

→ ✓ `0` が返る

## 検証済みの内容

| 項目 | 結果 |
|---|---|
| `phpunit.root.xml` | OK (5 tests, 31 assertions) |
| `phpunit.g2.xml` | OK (24 tests, 158 assertions) |
| `phpunit.g3.xml` | OK (23 tests, 148 assertions) |
| 実行後の作業ツリー | クリーン・`theme.json` 健在 |
| `_theme.json` 始まりからの実行 | 初期状態を保持 |

## 既知の限界

`register_shutdown_function()` は SIGINT（Ctrl+C）・SIGKILL・segfault では実行されません。ただし `tear_down()` による毎テスト復元が入ったことで露出窓は「1 テストの実行中」まで縮んでおり、かつ `_theme.json` は `.gitignore` に含まれないため、万一残っても `git status` に必ず現れます。`pcntl_signal()` まで入れるのは費用対効果が合わないと判断しました。

## 関連

- 元 PR: #1377 / #1386（分割前）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * テスト実行後に変更された `theme.json` 関連ファイル名が自動的に復元されるようになりました。
  * テスト間でファイル状態が引き継がれる問題を防止しました。

* **テスト**
  * テストスイートの識別名を追加し、テスト対象を明確化しました。
  * CLIおよびデバッグ実行時のファイル状態を保護するチェックを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
