### PR TITLE
[ その他 ][ G3 ] スライダーが出力する Swiper 非推奨クラスに、利用者のカスタム CSS 互換のため除去しない方針と非推奨クラス一覧のコメントを追記

### DIFF
--- a/_g3/inc/ltg-g3-slider/package/class-ltg-g3-slider.php
+++ b/_g3/inc/ltg-g3-slider/package/class-ltg-g3-slider.php
@@ -767,6 +767,24 @@ if ( ! class_exists( 'LTG_G3_Slider' ) ) {
 
 			if ( $slide_count ) {
 
+				/*
+				 * [ Deprecated Swiper class names / Swiper 非推奨クラス一覧 — DO NOT REMOVE from output ]
+				 *
+				 * The following classes no longer exist in the bundled Swiper itself,
+				 * but end users are likely to target them in their custom CSS,
+				 * so they are intentionally kept in the markup for backward compatibility.
+				 * Removing them will silently break users' customizations.
+				 *
+				 * 以下のクラスは同梱の Swiper 本体にはすでに定義が存在しない非推奨クラスだが、
+				 * 利用者が追加 CSS のセレクタとして使用している可能性が高いため、
+				 * 後方互換を目的として意図的に出力を維持している。
+				 * 出力から除去すると利用者のカスタマイズが予告なく効かなくなるため、安易に除去しないこと。
+				 *
+				 * - swiper-container        : renamed to .swiper in Swiper v8 / Swiper v8 で .swiper にリネーム
+				 * - swiper-pagination-white : replaced by CSS variables since Swiper 6 / Swiper 6 世代で CSS 変数方式に置換
+				 * - swiper-button-white     : replaced by CSS variables since Swiper 6 / Swiper 6 世代で CSS 変数方式に置換
+				 */
+
 				// class 名の swiper が２つ記載してあるように見えるが一つ目は $slider_prefix と結合される.
 				$slide_html .= '<div class="' . $slider_prefix . 'swiper swiper swiper-container ltg-slide">';
 				$slide_html .= '<div class="swiper-wrapper ltg-slide-inner">';
@@ -888,8 +906,12 @@ if ( ! class_exists( 'LTG_G3_Slider' ) ) {
 				$slide_html .= '</div><!-- [ /.swiper-wrapper ] -->';
 				if ( $slide_count >= 2 ) {
 					// Add Pagination.
+					// swiper-pagination-white is deprecated but kept for backward compatibility. See the note above the container markup.
+					// swiper-pagination-white は非推奨だが後方互換のため維持。コンテナ出力前のコメントを参照.
 					$slide_html .= '<div class="swiper-pagination swiper-pagination-white"></div>';
 					// Add Arrows.
+					// swiper-button-white is deprecated but kept for backward compatibility. See the note above the container markup.
+					// swiper-button-white は非推奨だが後方互換のため維持。コンテナ出力前のコメントを参照.
 					$slide_html .= '<div class="ltg-slide-button-next swiper-button-next swiper-button-white"></div>';
 					$slide_html .= '<div class="ltg-slide-button-prev swiper-button-prev swiper-button-white"></div>';
 				}


### PR DESCRIPTION
## 概要

トップページスライダーのマークアップには、Swiper 本体にはすでに定義が存在しないクラス（`swiper-container` / `swiper-pagination-white` / `swiper-button-white`）が出力されています。

#1393 でこれらの除去が提案されましたが、特に `swiper-container` は**一般ユーザーが追加 CSS のセレクタとして使っている可能性が高く、除去すると利用者のカスタマイズが予告なく効かなくなる**ため、除去しない方針としました（告知しても見ないユーザーが多いため）。

この PR は動作を一切変えず、将来誤って除去されないように、出力箇所のコード（`_g3/inc/ltg-g3-slider/package/class-ltg-g3-slider.php`）へ以下のコメントを追記します。

- コンテナ出力の直前: 非推奨クラス 3 つの一覧（各クラスが Swiper 側でいつ廃止されたか）と、「後方互換のため意図的に出力を維持している。安易に除去しないこと」という方針の明記
- ページネーション・矢印の出力行: 一覧コメントへの参照

changelog（readme.txt）は、コメントのみでエンドユーザーに影響しない変更のため追記していません。

関連 issue: https://github.com/vektor-inc/lightning/issues/1384

## 確認手順

1. この PR の Files changed を開く
   → 変更が `class-ltg-g3-slider.php` のコメント追記のみ（22 行追加・削除なし）で、`$slide_html` に連結される HTML 文字列には一切変更がないことを確認
2. （任意）このブランチをチェックアウトし、スライダーを設定したトップページを表示してページソースを確認
   → スライダーの div に `swiper-container` / `swiper-pagination-white` / `swiper-button-white` が従来どおり出力されていることを確認

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)