### PR TITLE
[ 開発環境 ][ G3 ] ブログカードのテストが外部サイトへの実通信に依存し、無関係な PR の CI まで不定期に失敗する問題を修正

### DIFF
--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -36,13 +36,13 @@ class BlogCardTest extends WP_UnitTestCase {
 	/**
 	 * テスト前処理: 外部サイトへの HTTP リクエストを固定レスポンスに差し替えるモックを登録
 	 *
-	 * CI 環境から外部 OGP サイトへ接続できるかどうか、および接続できた場合でも
+	 * CI 環境から外部サイトへ接続できるかどうか、および接続できた場合でも
 	 * 1リクエスト毎にレスポンスが変わり得ることで `oembed_html` / `maybe_make_link`
 	 * の出力が変動し、テストが flaky 化していた。
 	 * `pre_http_request` でドメイン毎の固定レスポンスを返すことで、
 	 * 実通信なしで各ケースの検証経路を安定させる。
 	 *
-	 * 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed discovery）にも
+	 * 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed 取得）にも
 	 * 同じモックを効かせる必要があるため、`set_up` 段階でフィルタを登録している。
 	 *
 	 * あわせて、`the_content` に対する `wpautop` フィルタの登録状態を記憶しておく。
@@ -76,25 +76,16 @@ class BlogCardTest extends WP_UnitTestCase {
 	 * 外部サイト宛ての HTTP リクエストをドメイン毎の固定レスポンスに差し替えるモック
 	 *
 	 * `pre_http_request` フィルタは false 以外を返すと実際の HTTP 通信を行わずに
-	 * その値を結果として使う仕様。
+	 * その値を結果として使う仕様.
 	 * これを利用して、テストが依存する外部ドメインについてのみ固定値を返し、
-	 * それ以外（サイト内リンクや YouTube oEmbed など）はそのまま通すために `$pre` を返す。
+	 * それ以外のドメインはそのまま通すために `$pre` を返す.
 	 *
-	 * ドメイン毎の固定内容は以下の通りで、各テストケースが検証したい経路を維持している。
-	 *
-	 * - vektor-inc.co.jp    : `WP_Error`（取得失敗 => URL のみのフォールバック表示）
-	 * - whitehouse.gov      : `WP_Error`（外部からの接続を拒否しているサイトの想定）
-	 * - github.com          : 200 + UTF-8 の OGP 入り HTML（ブログカード生成経路）
-	 * - abehiroshi.la.coocan.jp : 200 + Shift_JIS の HTML（`encode()` の文字コード変換）
-	 *
-	 * 返す配列は `wp_remote_get()` の戻り値と同じ形にしておく必要がある
-	 * （`VK_WP_Oembed_Blog_Card::vk_get_blog_card()` が
-	 * `$response['response']['code']` と `$response['body']` を参照するため）。
+	 * どのドメインに何を返すかは `get_mock_http_map()` を唯一の定義元とする.
 	 *
 	 * @param false|array|WP_Error $pre  既存の pre_http_request の戻り値（通常 false）.
 	 * @param array                $args HTTP リクエストの引数.
 	 * @param string               $url  リクエスト先 URL.
-	 * @return false|array|WP_Error 対象ドメインなら固定レスポンス、それ以外は $pre をそのまま返す
+	 * @return false|array|WP_Error 対象ドメインなら固定レスポンス、それ以外は $pre をそのまま返す.
 	 */
 	public function mock_http_request( $pre, $args, $url ) {
 		// クエリ文字列やパスにドメイン名が含まれているケースで誤反応しないよう、
@@ -103,47 +94,15 @@ class BlogCardTest extends WP_UnitTestCase {
 		if ( ! is_string( $host ) ) {
 			return $pre;
 		}
+		// 末尾ドット付きの絶対 FQDN 表記（例: github.com.）も同一ホストとして扱う.
+		$host = rtrim( $host, '.' );
 
-		// 取得失敗（WP_Error）を返すドメイン
-		// vektor-inc.co.jp は test_vk_get_post_data_blog_card() 用、
-		// whitehouse.gov は「外部からの接続を拒否しているサイト」のケース用.
-		$error_domains = array( 'vektor-inc.co.jp', 'whitehouse.gov' );
-		foreach ( $error_domains as $domain ) {
-			if ( $this->is_matched_host( $host, $domain ) ) {
-				return new \WP_Error( 'http_request_failed', 'mocked' );
+		foreach ( $this->get_mock_http_map() as $mock ) {
+			foreach ( $mock['domains'] as $domain ) {
+				if ( $this->is_matched_host( $host, $domain ) ) {
+					return $mock['response'];
+				}
 			}
-		}
-
-		// WordPress で作られていないサイトのブログカード生成用の固定 HTML（UTF-8）
-		// oEmbed discovery に拾われて経路が変わらないよう、
-		// `application/json+oembed` の link 要素はあえて含めていない.
-		if ( $this->is_matched_host( $host, 'github.com' ) ) {
-			$body = '<!DOCTYPE html><html lang="en"><head>'
-				. '<meta charset="utf-8">'
-				. '<title>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</title>'
-				. '<meta property="og:description" content="Lightning is a WordPress theme.">'
-				. '<meta property="og:image" content="https://github.com/vektor-inc/lightning/og-image.png">'
-				. '<meta property="og:site_name" content="GitHub">'
-				. '<link rel="icon" href="https://github.com/favicon.ico">'
-				. '</head><body></body></html>';
-			return $this->get_mock_response( $body );
-		}
-
-		// HTML の文字コードが UTF-8 でないサイト用の固定 HTML
-		// `VK_WP_Oembed_Blog_Card::encode()` による文字コード変換を検証するため、
-		// 日本語を含む HTML を Shift_JIS に変換して返す.
-		if ( $this->is_matched_host( $host, 'abehiroshi.la.coocan.jp' ) ) {
-			$body = '<!DOCTYPE html><html lang="ja"><head>'
-				. '<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">'
-				. '<title>阿部寛のホームページ</title>'
-				. '<meta property="og:description" content="阿部寛の公式ホームページです。">'
-				. '<meta property="og:site_name" content="阿部寛のホームページ">'
-				. '</head><body></body></html>';
-			// mb_convert_encoding が無い環境では変換できないため UTF-8 のまま返す.
-			if ( function_exists( 'mb_convert_encoding' ) ) {
-				$body = mb_convert_encoding( $body, 'SJIS', 'UTF-8' );
-			}
-			return $this->get_mock_response( $body );
 		}
 
 		// それ以外のドメインは通常通り処理させる.
@@ -151,32 +110,132 @@ class BlogCardTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * モックするドメインと、そのドメインに返す固定レスポンスの対応表を返す
+	 *
+	 * 各要素は以下のキーを持つ.
+	 *
+	 * - `domains`  : 対象ドメインの配列（サブドメインも一致する）.
+	 * - `response` : `wp_remote_get()` の戻り値と同じ形の配列、または `WP_Error`.
+	 *
+	 * `VK_WP_Oembed_Blog_Card::vk_get_blog_card()` は
+	 * `$response['response']['code']` と `$response['body']` を参照するため、
+	 * 配列を返す場合は `get_mock_response()` で組み立てる.
+	 *
+	 * @return array ドメインと固定レスポンスの対応表.
+	 */
+	private function get_mock_http_map() {
+		// WordPress で作られていないサイトのブログカード生成用の固定 HTML（UTF-8）.
+		// oEmbed discovery に拾われて経路が変わらないよう、
+		// `application/json+oembed` の link 要素はあえて含めていない.
+		$github_html = '<!DOCTYPE html><html lang="en"><head>'
+			. '<meta charset="utf-8">'
+			. '<title>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</title>'
+			. '<meta property="og:description" content="Lightning is a WordPress theme.">'
+			. '<meta property="og:image" content="https://github.com/vektor-inc/lightning/og-image.png">'
+			. '<meta property="og:site_name" content="GitHub">'
+			. '<link rel="icon" href="https://github.com/favicon.ico">'
+			. '</head><body></body></html>';
+
+		// HTML の文字コードが UTF-8 でないサイト用の固定 HTML.
+		// `VK_WP_Oembed_Blog_Card::encode()` による文字コード変換を検証するため、
+		// 日本語を含む HTML を Shift_JIS に変換して返す.
+		$sjis_html = '<!DOCTYPE html><html lang="ja"><head>'
+			. '<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">'
+			. '<title>阿部寛のホームページ</title>'
+			. '<meta property="og:description" content="阿部寛の公式ホームページです。">'
+			. '<meta property="og:site_name" content="阿部寛のホームページ">'
+			. '</head><body></body></html>';
+		// mb_convert_encoding が無い環境では変換できないため UTF-8 のまま返す.
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+			$sjis_html = mb_convert_encoding( $sjis_html, 'SJIS', 'UTF-8' );
+		}
+
+		// YouTube の oEmbed レスポンス.
+		// youtu.be は WordPress に登録済みのプロバイダーのため、
+		// discovery ではなく oEmbed エンドポイントが直接叩かれる.
+		// `WP_oEmbed::_fetch_with_format()` は content-type を見ずに body を JSON としてパースする.
+		// 出力される iframe の `loading="lazy"` と `title=` はコア側の
+		// `wp_filter_oembed_result()` が付与するため、ここでは含めない.
+		$youtube_json = wp_json_encode(
+			array(
+				'type'          => 'video',
+				'version'       => '1.0',
+				'title'         => 'WordPressテーマ Lightning (G3) クイックスタート【公式】',
+				'provider_name' => 'YouTube',
+				'provider_url'  => 'https://www.youtube.com/',
+				'width'         => 1140,
+				'height'        => 641,
+				'html'          => '<iframe width="1140" height="641" src="https://www.youtube.com/embed/OCYupuj5HrQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+			)
+		);
+
+		return array(
+			// 接続自体に失敗するサイト（WP_Error）.
+			// test_vk_get_post_data_blog_card() の外部 URL ケース用.
+			array(
+				'domains'  => array( 'vektor-inc.co.jp' ),
+				'response' => new WP_Error( 'http_request_failed', 'mocked' ),
+			),
+			// 外部からの接続を拒否しているサイト.
+			// `vk_get_blog_card()` の「200 / 304 以外のステータスコード」分岐を通すため、
+			// WP_Error ではなく 403 のレスポンスを返す.
+			array(
+				'domains'  => array( 'whitehouse.gov' ),
+				'response' => $this->get_mock_response( '', 403 ),
+			),
+			// WordPress で作られていないサイト（ブログカード生成経路）.
+			array(
+				'domains'  => array( 'github.com' ),
+				'response' => $this->get_mock_response( $github_html ),
+			),
+			// HTML の文字コードが UTF-8 でないサイト（`encode()` の文字コード変換）.
+			array(
+				'domains'  => array( 'abehiroshi.la.coocan.jp' ),
+				'response' => $this->get_mock_response( $sjis_html, 200, 'text/html; charset=Shift_JIS' ),
+			),
+			// WordPress が許可しているプロバイダー（YouTube）.
+			array(
+				'domains'  => array( 'youtube.com', 'youtu.be' ),
+				'response' => $this->get_mock_response( $youtube_json, 200, 'application/json' ),
+			),
+		);
+	}
+
+	/**
 	 * host が対象ドメイン（サブドメイン含む）に一致するか判定する
 	 *
 	 * 完全一致に加えて、末尾一致かつ直前が `.` の場合も一致とみなすことで
-	 * サブドメイン（例: www.vektor-inc.co.jp）も拾う。
+	 * サブドメイン（例: www.vektor-inc.co.jp）も拾う.
+	 * 末尾ドット付きの host は呼び出し側で除去済みである前提.
 	 *
 	 * @param string $host   `wp_parse_url()` で取り出した host.
 	 * @param string $domain 判定対象のドメイン（例: vektor-inc.co.jp）.
-	 * @return bool 一致すれば true。
+	 * @return bool 一致すれば true.
 	 */
 	private function is_matched_host( $host, $domain ) {
 		return (bool) preg_match( '/(^|\.)' . preg_quote( $domain, '/' ) . '$/i', $host );
 	}
 
 	/**
-	 * `wp_remote_get()` の戻り値と同じ形の、ステータス 200 の固定レスポンスを組み立てる
+	 * `wp_remote_get()` の戻り値と同じ形の固定レスポンスを組み立てる
 	 *
-	 * @param string $body レスポンスボディとして返す HTML.
-	 * @return array wp_remote_get() 互換のレスポンス配列。
+	 * @param string $body         レスポンスボディ.
+	 * @param int    $code         HTTP レスポンスステータスコード.
+	 * @param string $content_type Content-Type ヘッダの値.
+	 * @return array wp_remote_get() 互換のレスポンス配列.
 	 */
-	private function get_mock_response( $body ) {
+	private function get_mock_response( $body, $code = 200, $content_type = 'text/html; charset=UTF-8' ) {
+		// ステータスコードに対応する reason phrase.
+		$messages = array(
+			200 => 'OK',
+			403 => 'Forbidden',
+		);
 		return array(
-			'headers'  => array(),
+			'headers'  => array( 'content-type' => $content_type ),
 			'body'     => $body,
 			'response' => array(
-				'code'    => 200,
-				'message' => 'OK',
+				'code'    => $code,
+				'message' => isset( $messages[ $code ] ) ? $messages[ $code ] : '',
 			),
 			'cookies'  => array(),
 			'filename' => null,
@@ -184,14 +243,47 @@ class BlogCardTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * 生成結果に対する包含・非包含のアサーションを実行する
+	 *
+	 * `correct`（`the_content` 経由の期待値）との比較だけでは、
+	 * 期待値も実測値も同じ関数の同じ経路に行き着くため恒真になってしまう.
+	 * そのため、どの経路を通って何が出力されたかをリテラルで固定して検証する.
+	 *
+	 * @param array  $test_case テストケース（`contains` / `not_contains` / `matches` / `test_condition_name`）.
+	 * @param string $result 実際に生成された HTML.
+	 * @return void
+	 */
+	private function assert_blog_card_contents( $test_case, $result ) {
+		// 含まれているべき文字列.
+		if ( ! empty( $test_case['contains'] ) ) {
+			foreach ( $test_case['contains'] as $needle ) {
+				$this->assertStringContainsString( $needle, $result, $test_case['test_condition_name'] );
+			}
+		}
+		// 一致すべき正規表現（テンプレートのインデントを挟む箇所の検証に使う）.
+		if ( ! empty( $test_case['matches'] ) ) {
+			foreach ( $test_case['matches'] as $pattern ) {
+				$this->assertMatchesRegularExpression( $pattern, $result, $test_case['test_condition_name'] );
+			}
+		}
+		// 含まれていてはいけない文字列.
+		if ( ! empty( $test_case['not_contains'] ) ) {
+			foreach ( $test_case['not_contains'] as $needle ) {
+				$this->assertStringNotContainsString( $needle, $result, $test_case['test_condition_name'] );
+			}
+		}
+	}
+
+	/**
 	 * oembed_html 内部リンク、WordPressで作られたサイトのテスト
 	 * cache は 管理画面URLを貼り付けた時に自動で変換される文字列
 	 *
-	 * vektor-inc.co.jp の OGP 取得は `mock_http_request` で失敗固定しているため、
-	 * 期待値（`correct`）も実出力もフォールバック HTML（URL のみのリンク）となる。
+	 * 外部サイトへのリクエストはすべて `mock_http_request` で固定しているため、
+	 * 実通信は発生せず、外部サイトの状態に結果が左右されない.
+	 * vektor-inc.co.jp は取得失敗固定のため、URL のみのフォールバック表示となる.
 	 */
-	function test_vk_get_post_data_blog_card() {
-		// Create test post
+	public function test_vk_get_post_data_blog_card() {
+		// テスト用の投稿を作成.
 		$post    = array(
 			'post_title'   => 'test',
 			'post_content' => 'content',
@@ -200,33 +292,57 @@ class BlogCardTest extends WP_UnitTestCase {
 		);
 		$post_id = wp_insert_post( $post );
 
-		// the_contentのフィルターフックで自動に入るpタグを削除
+		// the_contentのフィルターフックで自動に入るpタグを削除.
 		remove_filter( 'the_content', 'wpautop' );
 		$test_array = array(
-			// WordPressで作られたサイト サイト内記事
-
+			// WordPressで作られたサイト サイト内記事.
 			array(
-				'url'     => get_permalink( $post_id ),
-				'cache'   => '[embed]' . get_permalink( $post_id ) . '[/embed]',
-				'correct' => apply_filters( 'the_content', '[embed]' . get_permalink( $post_id ) . '[/embed]' ),
+				'test_condition_name' => 'サイト内記事の URL の場合 => 投稿情報から生成したブログカード',
+				'url'                 => get_permalink( $post_id ),
+				'cache'               => '[embed]' . get_permalink( $post_id ) . '[/embed]',
+				'correct'             => apply_filters( 'the_content', '[embed]' . get_permalink( $post_id ) . '[/embed]' ),
+				'contains'            => array(
+					'class="blog-card"',
+					'>test</a>',
+					'content',
+				),
+				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),
-			// WordPressで作られたサイト トップページ
+			// WordPressで作られたサイト トップページ.
 			array(
-				'url'     => 'https://www.vektor-inc.co.jp/',
-				'cache'   => '[embed]https://www.vektor-inc.co.jp/[/embed]',
-				'correct' => apply_filters( 'the_content', '[embed]https://www.vektor-inc.co.jp/[/embed]' ),
+				'test_condition_name' => '外部サイト（取得失敗）のトップページの場合 => URL のみのフォールバック表示',
+				'url'                 => 'https://www.vektor-inc.co.jp/',
+				'cache'               => '[embed]https://www.vektor-inc.co.jp/[/embed]',
+				'correct'             => apply_filters( 'the_content', '[embed]https://www.vektor-inc.co.jp/[/embed]' ),
+				'contains'            => array(
+					'vk-wp-oembed-blog-card-url-template',
+					'https://www.vektor-inc.co.jp/',
+				),
+				'not_contains'        => array( 'class="blog-card"' ),
 			),
-			// WordPressで作られたサイト 下層ページ
+			// WordPressで作られたサイト 下層ページ.
 			array(
-				'url'     => 'https://www.vektor-inc.co.jp/service/',
-				'cache'   => '[embed]https://www.vektor-inc.co.jp/service/[/embed]',
-				'correct' => apply_filters( 'the_content', '[embed]https://www.vektor-inc.co.jp/service/[/embed]' ),
+				'test_condition_name' => '外部サイト（取得失敗）の下層ページの場合 => URL のみのフォールバック表示',
+				'url'                 => 'https://www.vektor-inc.co.jp/service/',
+				'cache'               => '[embed]https://www.vektor-inc.co.jp/service/[/embed]',
+				'correct'             => apply_filters( 'the_content', '[embed]https://www.vektor-inc.co.jp/service/[/embed]' ),
+				'contains'            => array(
+					'vk-wp-oembed-blog-card-url-template',
+					'https://www.vektor-inc.co.jp/service/',
+				),
+				'not_contains'        => array( 'class="blog-card"' ),
 			),
-			// WordPressが許可しているプロバイダ−の場合
+			// WordPressが許可しているプロバイダ−の場合.
 			array(
-				'url'     => 'https://youtu.be/OCYupuj5HrQ',
-				'cache'   => '<iframe loading="lazy" title="WordPressテーマ Lightning (G3) クイックスタート【公式】" width="1140" height="641" src="https://www.youtube.com/embed/OCYupuj5HrQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
-				'correct' => apply_filters( 'the_content', '[embed]https://youtu.be/OCYupuj5HrQ[/embed]' ),
+				'test_condition_name' => 'WordPress が許可しているプロバイダー（YouTube）の場合 => ブログカードにせず埋め込み iframe',
+				'url'                 => 'https://youtu.be/OCYupuj5HrQ',
+				'cache'               => '<iframe loading="lazy" title="WordPressテーマ Lightning (G3) クイックスタート【公式】" width="1140" height="641" src="https://www.youtube.com/embed/OCYupuj5HrQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+				'correct'             => apply_filters( 'the_content', '[embed]https://youtu.be/OCYupuj5HrQ[/embed]' ),
+				'contains'            => array(
+					'https://www.youtube.com/embed/OCYupuj5HrQ?feature=oembed',
+					'title="WordPressテーマ Lightning (G3) クイックスタート【公式】"',
+				),
+				'not_contains'        => array( 'class="blog-card"' ),
 			),
 		);
 		foreach ( $test_array as $key => $value ) {
@@ -234,9 +350,11 @@ class BlogCardTest extends WP_UnitTestCase {
 			if ( function_exists( 'wp_img_tag_add_loading_optimization_attrs' ) ) {
 				$result = wp_img_tag_add_loading_optimization_attrs( $result, 'custom' );
 			}
-			$this->assertEquals( $value['correct'], $result );
+			$this->assertEquals( $value['correct'], $result, $value['test_condition_name'] );
+			// `correct` との比較は同じ経路同士の比較になり得るため、経路をリテラルで固定して検証する.
+			$this->assert_blog_card_contents( $value, $result );
 		}
-		// wpautopフィルターフックを戻す
+		// wpautopフィルターフックを戻す.
 		add_filter( 'the_content', 'wpautop' );
 		wp_delete_post( $post_id );
 	}
@@ -245,26 +363,59 @@ class BlogCardTest extends WP_UnitTestCase {
 	 * embed_maybe_make_link 外部リンクのテスト
 	 *
 	 * 各 URL のレスポンスは `mock_http_request` で固定しているため、
-	 * 外部サイトの状態に依存せず、期待値（`correct`）と実出力が同じ経路を通る。
+	 * 外部サイトの状態に依存せず結果が決まる.
 	 */
-	function test_vk_get_blog_card() {
-		// the_contentのフィルターフックで自動に入るpタグを削除
+	public function test_vk_get_blog_card() {
+		// 文字コード変換のケースが形骸化しないよう、モックが本当に Shift_JIS
+		// （UTF-8 としては不正なバイト列）を返していることを先に確認する.
+		// UTF-8 のまま返すと `encode()` が実質的に何もしない状態になり、変換の検証にならない.
+		$sjis_response = $this->mock_http_request( false, array(), 'http://abehiroshi.la.coocan.jp/' );
+		$this->assertFalse(
+			mb_check_encoding( $sjis_response['body'], 'UTF-8' ),
+			'abehiroshi.la.coocan.jp のモックが UTF-8 を返しており、encode() の文字コード変換が検証されない'
+		);
+
+		// the_contentのフィルターフックで自動に入るpタグを削除.
 		remove_filter( 'the_content', 'wpautop' );
 		$test_array = array(
-			// WordPressでは作られていないサイト
+			// WordPressでは作られていないサイト.
 			array(
-				'url'     => 'https://github.com/vektor-inc/lightning',
-				'correct' => apply_filters( 'the_content', '[embed]https://github.com/vektor-inc/lightning[/embed]' ),
+				'test_condition_name' => 'WordPress で作られていないサイト（取得成功）の場合 => OGP からブログカードを生成',
+				'url'                 => 'https://github.com/vektor-inc/lightning',
+				'correct'             => apply_filters( 'the_content', '[embed]https://github.com/vektor-inc/lightning[/embed]' ),
+				'contains'            => array(
+					'class="blog-card"',
+					'>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</a>',
+					'Lightning is a WordPress theme.',
+					'https://github.com/vektor-inc/lightning/og-image.png',
+					'https://github.com/favicon.ico',
+				),
+				// og:site_name がサイト名として出力されていること（ドメイン名へのフォールバックではないこと）.
+				'matches'             => array( '/blog-card-site-title.*?>\s*GitHub\s*<\/a>/s' ),
+				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),
-			// 外部からの接続を拒否しているサイト
+			// 外部からの接続を拒否しているサイト（403）.
 			array(
-				'url'     => 'https://www.whitehouse.gov/',
-				'correct' => apply_filters( 'the_content', '[embed]https://www.whitehouse.gov/[/embed]' ),
+				'test_condition_name' => '外部からの接続を拒否しているサイト（403）の場合 => URL のみのフォールバック表示',
+				'url'                 => 'https://www.whitehouse.gov/',
+				'correct'             => apply_filters( 'the_content', '[embed]https://www.whitehouse.gov/[/embed]' ),
+				'contains'            => array(
+					'vk-wp-oembed-blog-card-url-template',
+					'https://www.whitehouse.gov/',
+				),
+				'not_contains'        => array( 'class="blog-card"' ),
 			),
-			// HTMLの文字コードが異なるサイト
+			// HTMLの文字コードが異なるサイト.
 			array(
-				'url'     => 'http://abehiroshi.la.coocan.jp/',
-				'correct' => apply_filters( 'the_content', '[embed]http://abehiroshi.la.coocan.jp/[/embed]' ),
+				'test_condition_name' => 'HTML の文字コードが Shift_JIS のサイトの場合 => UTF-8 に変換してブログカードを生成',
+				'url'                 => 'http://abehiroshi.la.coocan.jp/',
+				'correct'             => apply_filters( 'the_content', '[embed]http://abehiroshi.la.coocan.jp/[/embed]' ),
+				'contains'            => array(
+					'class="blog-card"',
+					'>阿部寛のホームページ</a>',
+					'阿部寛の公式ホームページです。',
+				),
+				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),
 		);
 		foreach ( $test_array as $key => $value ) {
@@ -273,9 +424,11 @@ class BlogCardTest extends WP_UnitTestCase {
 			if ( function_exists( 'wp_img_tag_add_loading_optimization_attrs' ) ) {
 				$result = wp_img_tag_add_loading_optimization_attrs( $result, 'custom' );
 			}
-			$this->assertEquals( $value['correct'], $result );
+			$this->assertEquals( $value['correct'], $result, $value['test_condition_name'] );
+			// `correct` との比較は同じ経路同士の比較になり得るため、経路をリテラルで固定して検証する.
+			$this->assert_blog_card_contents( $value, $result );
 		}
-		// wpautopフィルターフックを戻す
+		// wpautopフィルターフックを戻す.
 		add_filter( 'the_content', 'wpautop' );
 	}
 }

--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -130,7 +130,9 @@ class BlogCardTest extends WP_UnitTestCase {
 		$github_html = '<!DOCTYPE html><html lang="en"><head>'
 			. '<meta charset="utf-8">'
 			. '<title>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</title>'
-			. '<meta property="og:description" content="Lightning is a WordPress theme.">'
+			// `<title>` と同じ文言にすると、description が出力されなくても
+			// タイトル側の検証だけでアサーションが通ってしまうため、別の文言にしている.
+			. '<meta property="og:description" content="Lightning is a very simple theme for business sites.">'
 			. '<meta property="og:image" content="https://github.com/vektor-inc/lightning/og-image.png">'
 			. '<meta property="og:site_name" content="GitHub">'
 			. '<link rel="icon" href="https://github.com/favicon.ico">'
@@ -304,8 +306,9 @@ class BlogCardTest extends WP_UnitTestCase {
 				'contains'            => array(
 					'class="blog-card"',
 					'>test</a>',
-					'content',
 				),
+				// 抜粋が説明文の要素として出力されていること（3文字の一般語の単独包含では弱いため要素ごと固定する）.
+				'matches'             => array( '/<p class="blog-card-text">\s*content\s*<\/p>/' ),
 				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),
 			// WordPressで作られたサイト トップページ.
@@ -366,10 +369,21 @@ class BlogCardTest extends WP_UnitTestCase {
 	 * 外部サイトの状態に依存せず結果が決まる.
 	 */
 	public function test_vk_get_blog_card() {
+		// mbstring が無い環境では `get_mock_http_map()` が Shift_JIS のモックを作れず、
+		// 実装側の `encode()` も即 return するため、文字コード変換のケース自体が成立しない.
+		// 下の事前アサートが必ず失敗してしまうので、その環境ではテストごとスキップする.
+		if ( ! function_exists( 'mb_convert_encoding' ) ) {
+			$this->markTestSkipped( 'mbstring が無い環境では encode() の文字コード変換を検証できないためスキップする' );
+		}
+
 		// 文字コード変換のケースが形骸化しないよう、モックが本当に Shift_JIS
 		// （UTF-8 としては不正なバイト列）を返していることを先に確認する.
 		// UTF-8 のまま返すと `encode()` が実質的に何もしない状態になり、変換の検証にならない.
 		$sjis_response = $this->mock_http_request( false, array(), 'http://abehiroshi.la.coocan.jp/' );
+		$this->assertIsArray(
+			$sjis_response,
+			'abehiroshi.la.coocan.jp のモックがレスポンス配列を返していない（WP_Error 等に変わっていないか確認すること）'
+		);
 		$this->assertFalse(
 			mb_check_encoding( $sjis_response['body'], 'UTF-8' ),
 			'abehiroshi.la.coocan.jp のモックが UTF-8 を返しており、encode() の文字コード変換が検証されない'
@@ -386,12 +400,15 @@ class BlogCardTest extends WP_UnitTestCase {
 				'contains'            => array(
 					'class="blog-card"',
 					'>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</a>',
-					'Lightning is a WordPress theme.',
 					'https://github.com/vektor-inc/lightning/og-image.png',
 					'https://github.com/favicon.ico',
 				),
-				// og:site_name がサイト名として出力されていること（ドメイン名へのフォールバックではないこと）.
-				'matches'             => array( '/blog-card-site-title.*?>\s*GitHub\s*<\/a>/s' ),
+				'matches'             => array(
+					// og:description が説明文の要素として出力されていること.
+					'/<p class="blog-card-text">\s*Lightning is a very simple theme for business sites\.\s*<\/p>/',
+					// og:site_name がサイト名として出力されていること（ドメイン名へのフォールバックではないこと）.
+					'/blog-card-site-title.*?>\s*GitHub\s*<\/a>/s',
+				),
 				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),
 			// 外部からの接続を拒否しているサイト（403）.
@@ -415,7 +432,13 @@ class BlogCardTest extends WP_UnitTestCase {
 					'>阿部寛のホームページ</a>',
 					'阿部寛の公式ホームページです。',
 				),
-				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
+				'not_contains'        => array(
+					'vk-wp-oembed-blog-card-url-template',
+					// og:image を持たないサイトなので、空のサムネイル枠が出力されないこと.
+					'blog-card-image-outer',
+					// favicon も持たないサイトなので、空の img 要素が出力されないこと.
+					'width="16"',
+				),
 			),
 		);
 		foreach ( $test_array as $key => $value ) {

--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -34,12 +34,13 @@ class BlogCardTest extends WP_UnitTestCase {
 	private $had_wpautop = false;
 
 	/**
-	 * テスト前処理: vektor-inc.co.jp への HTTP リクエストを失敗固定するモックを登録
+	 * テスト前処理: 外部サイトへの HTTP リクエストを固定レスポンスに差し替えるモックを登録
 	 *
-	 * CI 環境から外部 OGP サイトへ接続できるかどうかで `oembed_html` / `maybe_make_link`
+	 * CI 環境から外部 OGP サイトへ接続できるかどうか、および接続できた場合でも
+	 * 1リクエスト毎にレスポンスが変わり得ることで `oembed_html` / `maybe_make_link`
 	 * の出力が変動し、テストが flaky 化していた。
-	 * `pre_http_request` で `WP_Error` を返すことで、常に「OGP 取得失敗時の
-	 * URL のみフォールバック表示」ケースを検証できるようにする。
+	 * `pre_http_request` でドメイン毎の固定レスポンスを返すことで、
+	 * 実通信なしで各ケースの検証経路を安定させる。
 	 *
 	 * 期待値生成側（`apply_filters( 'the_content', ... )` 内部の oEmbed discovery）にも
 	 * 同じモックを効かせる必要があるため、`set_up` 段階でフィルタを登録している。
@@ -52,7 +53,7 @@ class BlogCardTest extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		add_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
 		$this->had_wpautop = false !== has_filter( 'the_content', 'wpautop' );
 	}
 
@@ -67,40 +68,126 @@ class BlogCardTest extends WP_UnitTestCase {
 		if ( $this->had_wpautop && false === has_filter( 'the_content', 'wpautop' ) ) {
 			add_filter( 'the_content', 'wpautop' );
 		}
-		remove_filter( 'pre_http_request', array( $this, 'mock_http_fail' ), 10 );
+		remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10 );
 		parent::tear_down();
 	}
 
 	/**
-	 * vektor-inc.co.jp 宛ての HTTP リクエストを失敗として固定するためのモック
+	 * 外部サイト宛ての HTTP リクエストをドメイン毎の固定レスポンスに差し替えるモック
 	 *
 	 * `pre_http_request` フィルタは false 以外を返すと実際の HTTP 通信を行わずに
 	 * その値を結果として使う仕様。
-	 * vektor-inc.co.jp ドメインのリクエストのみ `WP_Error` を返して失敗扱いとし、
-	 * YouTube oEmbed や内部リンクなどはそのまま通すために `$pre` を返す。
+	 * これを利用して、テストが依存する外部ドメインについてのみ固定値を返し、
+	 * それ以外（サイト内リンクや YouTube oEmbed など）はそのまま通すために `$pre` を返す。
 	 *
-	 * @param false|array|WP_Error $pre  既存の pre_http_request の戻り値（通常 false）
-	 * @param array                $args HTTP リクエストの引数
-	 * @param string               $url  リクエスト先 URL
-	 * @return false|array|WP_Error vektor-inc.co.jp なら WP_Error、それ以外は $pre をそのまま返す
+	 * ドメイン毎の固定内容は以下の通りで、各テストケースが検証したい経路を維持している。
+	 *
+	 * - vektor-inc.co.jp    : `WP_Error`（取得失敗 => URL のみのフォールバック表示）
+	 * - whitehouse.gov      : `WP_Error`（外部からの接続を拒否しているサイトの想定）
+	 * - github.com          : 200 + UTF-8 の OGP 入り HTML（ブログカード生成経路）
+	 * - abehiroshi.la.coocan.jp : 200 + Shift_JIS の HTML（`encode()` の文字コード変換）
+	 *
+	 * 返す配列は `wp_remote_get()` の戻り値と同じ形にしておく必要がある
+	 * （`VK_WP_Oembed_Blog_Card::vk_get_blog_card()` が
+	 * `$response['response']['code']` と `$response['body']` を参照するため）。
+	 *
+	 * @param false|array|WP_Error $pre  既存の pre_http_request の戻り値（通常 false）.
+	 * @param array                $args HTTP リクエストの引数.
+	 * @param string               $url  リクエスト先 URL.
+	 * @return false|array|WP_Error 対象ドメインなら固定レスポンス、それ以外は $pre をそのまま返す
 	 */
-	public function mock_http_fail( $pre, $args, $url ) {
-		// クエリ文字列やパスに 'vektor-inc.co.jp' が含まれているケースで誤反応しないよう、
-		// `wp_parse_url` で host を厳密に取り出してマッチングする。
-		// 末尾一致＋直前が `.` であれば許可することでサブドメイン（例: blog.vektor-inc.co.jp）も拾う。
+	public function mock_http_request( $pre, $args, $url ) {
+		// クエリ文字列やパスにドメイン名が含まれているケースで誤反応しないよう、
+		// `wp_parse_url` で host を厳密に取り出してマッチングする.
 		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( is_string( $host ) && preg_match( '/(^|\.)vektor-inc\.co\.jp$/i', $host ) ) {
-			return new \WP_Error( 'http_request_failed', 'mocked' );
+		if ( ! is_string( $host ) ) {
+			return $pre;
 		}
-		// それ以外のドメインは通常通り処理させる
+
+		// 取得失敗（WP_Error）を返すドメイン
+		// vektor-inc.co.jp は test_vk_get_post_data_blog_card() 用、
+		// whitehouse.gov は「外部からの接続を拒否しているサイト」のケース用.
+		$error_domains = array( 'vektor-inc.co.jp', 'whitehouse.gov' );
+		foreach ( $error_domains as $domain ) {
+			if ( $this->is_matched_host( $host, $domain ) ) {
+				return new \WP_Error( 'http_request_failed', 'mocked' );
+			}
+		}
+
+		// WordPress で作られていないサイトのブログカード生成用の固定 HTML（UTF-8）
+		// oEmbed discovery に拾われて経路が変わらないよう、
+		// `application/json+oembed` の link 要素はあえて含めていない.
+		if ( $this->is_matched_host( $host, 'github.com' ) ) {
+			$body = '<!DOCTYPE html><html lang="en"><head>'
+				. '<meta charset="utf-8">'
+				. '<title>GitHub - vektor-inc/lightning: Lightning is a WordPress theme.</title>'
+				. '<meta property="og:description" content="Lightning is a WordPress theme.">'
+				. '<meta property="og:image" content="https://github.com/vektor-inc/lightning/og-image.png">'
+				. '<meta property="og:site_name" content="GitHub">'
+				. '<link rel="icon" href="https://github.com/favicon.ico">'
+				. '</head><body></body></html>';
+			return $this->get_mock_response( $body );
+		}
+
+		// HTML の文字コードが UTF-8 でないサイト用の固定 HTML
+		// `VK_WP_Oembed_Blog_Card::encode()` による文字コード変換を検証するため、
+		// 日本語を含む HTML を Shift_JIS に変換して返す.
+		if ( $this->is_matched_host( $host, 'abehiroshi.la.coocan.jp' ) ) {
+			$body = '<!DOCTYPE html><html lang="ja"><head>'
+				. '<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">'
+				. '<title>阿部寛のホームページ</title>'
+				. '<meta property="og:description" content="阿部寛の公式ホームページです。">'
+				. '<meta property="og:site_name" content="阿部寛のホームページ">'
+				. '</head><body></body></html>';
+			// mb_convert_encoding が無い環境では変換できないため UTF-8 のまま返す.
+			if ( function_exists( 'mb_convert_encoding' ) ) {
+				$body = mb_convert_encoding( $body, 'SJIS', 'UTF-8' );
+			}
+			return $this->get_mock_response( $body );
+		}
+
+		// それ以外のドメインは通常通り処理させる.
 		return $pre;
+	}
+
+	/**
+	 * host が対象ドメイン（サブドメイン含む）に一致するか判定する
+	 *
+	 * 完全一致に加えて、末尾一致かつ直前が `.` の場合も一致とみなすことで
+	 * サブドメイン（例: www.vektor-inc.co.jp）も拾う。
+	 *
+	 * @param string $host   `wp_parse_url()` で取り出した host.
+	 * @param string $domain 判定対象のドメイン（例: vektor-inc.co.jp）.
+	 * @return bool 一致すれば true。
+	 */
+	private function is_matched_host( $host, $domain ) {
+		return (bool) preg_match( '/(^|\.)' . preg_quote( $domain, '/' ) . '$/i', $host );
+	}
+
+	/**
+	 * `wp_remote_get()` の戻り値と同じ形の、ステータス 200 の固定レスポンスを組み立てる
+	 *
+	 * @param string $body レスポンスボディとして返す HTML.
+	 * @return array wp_remote_get() 互換のレスポンス配列。
+	 */
+	private function get_mock_response( $body ) {
+		return array(
+			'headers'  => array(),
+			'body'     => $body,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
 	}
 
 	/**
 	 * oembed_html 内部リンク、WordPressで作られたサイトのテスト
 	 * cache は 管理画面URLを貼り付けた時に自動で変換される文字列
 	 *
-	 * vektor-inc.co.jp の OGP 取得は `mock_http_fail` で失敗固定しているため、
+	 * vektor-inc.co.jp の OGP 取得は `mock_http_request` で失敗固定しているため、
 	 * 期待値（`correct`）も実出力もフォールバック HTML（URL のみのリンク）となる。
 	 */
 	function test_vk_get_post_data_blog_card() {
@@ -156,6 +243,9 @@ class BlogCardTest extends WP_UnitTestCase {
 
 	/**
 	 * embed_maybe_make_link 外部リンクのテスト
+	 *
+	 * 各 URL のレスポンスは `mock_http_request` で固定しているため、
+	 * 外部サイトの状態に依存せず、期待値（`correct`）と実出力が同じ経路を通る。
 	 */
 	function test_vk_get_blog_card() {
 		// the_contentのフィルターフックで自動に入るpタグを削除

--- a/_g3/tests/test-vk-wp-oembed-blog-card.php
+++ b/_g3/tests/test-vk-wp-oembed-blog-card.php
@@ -307,7 +307,7 @@ class BlogCardTest extends WP_UnitTestCase {
 					'class="blog-card"',
 					'>test</a>',
 				),
-				// 抜粋が説明文の要素として出力されていること（3文字の一般語の単独包含では弱いため要素ごと固定する）.
+				// 抜粋が説明文の要素として出力されていること（一般的な語の単独包含では弱いため要素ごと固定する）.
 				'matches'             => array( '/<p class="blog-card-text">\s*content\s*<\/p>/' ),
 				'not_contains'        => array( 'vk-wp-oembed-blog-card-url-template' ),
 			),


### PR DESCRIPTION
Closes #1328

## 概要

ブログカード（外部サイトの URL を貼ると、そのページのタイトル・説明文・画像を並べたカードで表示する機能）の PHPUnit テストが、テスト実行のたびに実際に外部サイトへアクセスしていました。そのため、GitHub Actions のランナーから相手サイトへ届くかどうかでテストの合否が変わり、**このテストと無関係な PR の CI まで不定期に失敗**していました。

外部サイトへのアクセスをすべてモック（あらかじめ用意した固定の応答に差し替える仕組み）に置き換えて、結果が実通信に左右されないようにしました。

変更したのはテストファイル 1 つだけで、テーマの動作そのものは変えていません。

## 背景

この不具合は #1339（`vektor-inc.co.jp` 宛てのリクエストを失敗として固定するモックを追加した対応）で一度直しましたが、モックの対象が `vektor-inc.co.jp` だけで、同じファイル内のもう一方のテストメソッドが素通しのまま残っていました。

直近では #1393（スライダーのマークアップから Swiper の廃止クラスを除去する対応）の CI がこれで落ちています。同一コミットにもかかわらず php 8 は成功し、php 7.4 と 8.1 が失敗しました。

### なぜ同じテストの中で結果がぶれるのか

ブログカードを組み立てる処理（`VK_WP_Oembed_Blog_Card::vk_get_blog_card()`）は取得結果をキャッシュせず、呼ばれるたびに `wp_remote_get()`（指定した URL の HTML を実際に取りに行く WordPress の関数）を実行します。

テストは同じ URL に対して 2 回アクセスする構造でした。

| 回 | 何のためのアクセスか |
|---|---|
| 1 回目 | 期待値の生成（テストケースの配列を組み立てる時点で実行される） |
| 2 回目 | 実際の出力の取得（ループの中でテスト対象を呼ぶ） |

この 2 回の応答が食い違うと失敗します。#1393 のときは 1 回目が非 200（URL だけを表示するフォールバックになる）、2 回目が 200（ブログカードが生成される）となっていました。

## 変更内容

### 1. ドメインごとに固定の応答を返し分ける

`pre_http_request`（WordPress が外部へ HTTP リクエストを投げる直前に割り込めるフィルター。ここで値を返すと実通信せずにその値が使われる）で差し替えます。一律に「取得失敗」で固定すると各テストケースが検証したい経路が失われるため、ケースごとに返す内容を変えています。

| ドメイン | 返すもの | そのケースが検証している経路 |
|---|---|---|
| `vektor-inc.co.jp` | `WP_Error`（通信自体の失敗） | 取得に失敗したときの、URL だけを表示するフォールバック |
| `whitehouse.gov` | ステータス 403 のレスポンス | 相手サーバーがアクセスを拒否した（200 以外が返った）ときのフォールバック |
| `github.com` | ステータス 200 ＋ OGP（ページのタイトル・説明文・画像などをまとめたメタ情報）入りの UTF-8 の HTML | ブログカードの生成 |
| `abehiroshi.la.coocan.jp` | ステータス 200 ＋ Shift_JIS の日本語 HTML | 文字コードを変換する処理（`encode()`）が文字化けを起こさないこと |
| `youtube.com` / `youtu.be` | oEmbed（動画などの埋め込み情報を返す仕組み）の JSON | YouTube のような埋め込み対応サービスの経路 |

`whitehouse.gov` を `WP_Error` ではなく 403 にしているのは、`vk_get_blog_card()` の失敗系が「通信自体が失敗する」と「200 / 304 以外のステータスが返る」の 2 通りあり、両方を別々に検証するためです。

### 2. テストが実際に表示内容を検証するようにした

修正前は、期待値を `apply_filters( 'the_content', '[embed]URL[/embed]' )` で実行時に生成していました。これは WordPress の内部で

`WP_Embed::shortcode()` → oEmbed の自動検出に失敗 → `WP_Embed::maybe_make_link()` → `embed_maybe_make_link` フィルター → `VK_WP_Oembed_Blog_Card::maybe_make_link()`

と流れ、比較相手である実際の出力とまったく同じ処理に行き着きます。つまり同じ入力で同じ処理を 2 回呼んで比べているだけで、**カードの中身が丸ごと空になってもテストは成功する**状態でした。

そこで各ケースに、利用者が実際に目にする文字列を直接確認するアサーション（検証）を追加しました。

- カードが出るべきケース … カードのクラス・タイトルのリンク文言・画像の URL・ファビコン・サイト名
- URL だけのフォールバックが出るべきケース … フォールバック用のクラスが出ること、かつカードのクラスが出ないこと
- 文字コードが UTF-8 でないサイトのケース … `阿部寛のホームページ` が文字化けせずに出ること
- 画像を持たないサイトのケース … 空のサムネイル枠・空のファビコンが出力されないこと

### 3. モック自体が劣化したときにも気づけるようにした

文字コード変換のケースは、モックが返す HTML を Shift_JIS ではなく UTF-8 にしてしまうと、変換処理が何もしなくても出力が同じになるため、出力の比較だけでは検証が無効になったことに気づけません。そのため、テストの冒頭でモックが返す HTML が UTF-8 として不正であること（＝ Shift_JIS のままであること）を直接確認しています。

## 動作確認の結果

### 実通信が発生しないこと

`pre_http_request` に検証用のフィルターを差し込み、モックで止まらずに実通信へ向かった URL を記録しました。

| 対象 | 修正前 | 修正後 |
|---|---|---|
| g3 スイート全体 | YouTube 宛て 2 件が漏れていた | **0 件** |

`WP_HTTP_BLOCK_EXTERNAL`（外部への通信をすべて禁止する WordPress の定数）を有効にした状態でも、g3 スイート全体が成功します。

### テストが実際に壊れを検出できること

意図的にモックや実装を壊して、テストが失敗するかを確認しました（ミューテーションテスト）。

| 壊した内容 | 修正前 | 修正後 |
|---|---|---|
| OGP のタイトル・説明文を別物に差し替え | 成功してしまう | **失敗する（検出できる）** |
| 説明文（og:description）だけを削除 | 成功してしまう | **失敗する** |
| 画像（og:image）を削除 | 成功してしまう | **失敗する** |
| 画像を持たないサイトに画像とファビコンを追加 | 成功してしまう | **失敗する** |
| Shift_JIS に変換せず UTF-8 のまま返す | 成功してしまう | **失敗する** |
| 取得成功のケースを取得失敗に変更 | 成功してしまう | **失敗する** |
| 403 のケースを 200 に変更 | 成功してしまう | **失敗する** |
| YouTube の埋め込み情報を壊す | 未検証（実通信のため） | **失敗する** |
| 実装側の説明文取得処理（`get_description()`）を改変 | 成功してしまう | **失敗する** |

### テストの実行結果

| スイート | 結果 |
|---|---|
| `phpunit.root.xml` | OK (5 tests, 31 assertions) |
| `phpunit.g2.xml` | OK (24 tests, 158 assertions) |
| `phpunit.g3.xml`（4 回連続） | OK (27 tests, 235 assertions) — 4 回とも同一 |
| `phpunit.g3.xml`（外部通信を禁止した状態） | OK (27 tests, 235 assertions) |

phpcs（コーディング規約のチェック）は、このファイルの指摘が 20 件から 0 件になりました。

## 確認手順

### 前提条件

- 本 PR のブランチをチェックアウトしていること
- `npx wp-env start` でテスト環境が起動していること

### 手順

#### Before（修正前の状態を確認する）※任意

1. `git checkout master` で修正前の状態にする
2. `_g3/tests/test-vk-wp-oembed-blog-card.php` を開き、`test_vk_get_blog_card()` を探す
3. `github.com` / `whitehouse.gov` / `abehiroshi.la.coocan.jp` の 3 つの URL に対して、モックが用意されていないことを確認する
   → ✗ テスト実行のたびに、これらのサイトへ実際にアクセスしている

#### After（修正後）

1. 本 PR のブランチに切り替える
2. 次のコマンドで g3 のテストを実行する

   ```
   npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.g3.xml
   ```

   → ✓ `OK (27 tests, 235 assertions)` と表示される
3. 同じコマンドをもう 2 回実行する
   → ✓ 3 回とも同じ結果（テスト数・アサーション数まで一致）になる
4. ネットワークを切断した状態で、もう一度同じコマンドを実行する
   → ✓ 変わらず成功する（外部サイトへアクセスしていないため）
5. `phpunit.root.xml` と `phpunit.g2.xml` でも実行する

   ```
   npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.root.xml
   npx wp-env run --env-cwd='wp-content/themes/lightning' tests-cli vendor/bin/phpunit -c phpunit.g2.xml
   ```

   → ✓ どちらも成功する（デグレしていない）

#### テストが壊れを検出できることの確認 ※任意

1. `_g3/inc/vk-wp-oembed-blog-card/package/class-vk-wp-oembed-blog-card.php` の `get_description()` を開く
2. 正規表現の `og:description` を `og:xxdescription` のように書き換える
3. g3 のテストを実行する
   → ✓ `test_vk_get_blog_card` が失敗する（＝説明文が出なくなったことをテストが検出できている）
4. `git checkout -- _g3/inc/vk-wp-oembed-blog-card/package/class-vk-wp-oembed-blog-card.php` で元に戻す
5. g3 のテストを実行する
   → ✓ 成功に戻る

## スクリーンショット

テストコードのみの変更で、テーマの表示・動作は変わらないため添付していません。

## 補足

### changelog を更新していない理由

変更したのは PHPUnit のテストコードのみで、エンドユーザーに影響する変更がないためです（`rules/changelog.md` の「更新不要なケース」）。

### 本 PR では対応していないこと

レビューで挙がったもののうち、本 PR のスコープ（外部通信への依存の解消と、テストの検証力の確保）から外れるものです。

- 画像を持たないサイトのケースで、空のファビコンが出ないことを `width="16"` の非包含で確認しています。ファビコン用の `img` 要素に専用のクラスが無いため現状これが最善ですが、将来ファビコンのサイズ指定を変えると、この確認が黙って無効になります。テンプレート側にクラスを追加する機会があれば、あわせて見直す価値があります
- mbstring（文字コードを扱う PHP の拡張機能）が入っていない環境では、文字コード変換のケースだけでなく同じテストメソッド内の他のケースもまとめてスキップされます。ケースを分ければ避けられますが、CI には mbstring が入っているため、分割の複雑さに見合わないと判断しました
- 説明文が長いときに `mb_strimwidth( $description, 0, 160, '…' )` で切り詰められる表示は未検証です。新しいモックとテストケースの追加が必要になります
- 取得に失敗したときのフォールバック表示は、リンクの文言が URL そのままです。スクリーンリーダーで URL が読み上げられるため WCAG 2.4.4 の観点で改善余地がありますが、本 PR の差分外の既存実装です


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ブログカードの取得テストを拡充し、HTTPエラー、アクセス拒否、OGP情報、文字コード変換、YouTube oEmbedなどのケースを検証できるようにしました。
  * 条件名や文字列の包含・非包含、正規表現リテラルの検証を追加しました。
  * `mbstring` が利用できない環境では、該当する文字コード変換テストを自動的にスキップします。
  * 外部通信に依存しない安定したテスト実行に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->