### PR TITLE
[ 開発環境 ] Dependabot の依存更新を安全なものだけ自動マージする設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+# Dependabot の設定
+#
+# 依存関係の更新 PR を毎週作成する。開発依存（ビルド・テスト用）の minor / patch 更新は
+# 1 本の PR にまとめ、dependabot-auto-merge ワークフローで CI 通過後に自動マージする。
+# 本番依存（配布物に含まれるライブラリ）と major 更新はグループに入らず個別の PR になり、
+# 人が確認する。
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # npm
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      npm-development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # ---------------------------------------------------------------------------
+  # Composer
+  # 開発依存（phpcs / PHPUnit 用）は配布物に含まれないため、まとめて自動マージ対象にする。
+  # 本番依存（vendor/ に入って配布されるもの）は changelog への記載が必要なため、
+  # グループに入れず個別の PR にする。
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      composer-development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -9,7 +9,17 @@ on:
 jobs:
   php_unit:
     name: php unittest
-    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
+    # Dependabot の PR は run-ci ラベル無しでも実行する。
+    # dependabot-auto-merge-complete.yml がこの結果を見てマージするため。
+    #
+    # ただし labeled のときは動かさない。Dependabot は PR を作った直後に
+    # dependencies / php などのラベルを次々付けるため、そのたびに
+    # CI が起動して同じ内容を何度もテストしてしまう。
+    # 人が run-ci ラベルを付けた場合は上の条件で拾われる。
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-ci') ||
+      (github.event.pull_request.user.login == 'dependabot[bot]' &&
+       github.event.action != 'labeled')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dependabot-auto-merge-complete.yml
+++ b/.github/workflows/dependabot-auto-merge-complete.yml
@@ -1,0 +1,98 @@
+# dependabot-auto-merge.yml が「自動マージ対象」と判定した PR を、CI 完了後にマージする。
+#
+# workflow_run はデフォルトブランチにあるこのファイルが使われるため、
+# Dependabot のブランチ側を書き換えてもマージ処理は変わらない。
+name: Dependabot auto-merge complete
+
+on:
+  workflow_run:
+    workflows:
+      - "PHP Unit Test"
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  merge:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 対象の PR をマージ
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          # CI のジョブがすべて実際に成功したかを確かめる。
+          # run 全体の結論は「一部のジョブが skip、残りが成功」でも success になるため、
+          # 条件付きで skip されたジョブがあるとテストを実行していない PR がマージされうる。
+          # ジョブが 1 つも無い run（すべて skip）もここで弾く。
+          jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")
+          job_count=$(echo "$jobs_json" | jq '.jobs | length')
+          not_success=$(echo "$jobs_json" \
+            | jq -r '[.jobs[] | select(.conclusion != "success") | "\(.name)=\(.conclusion)"] | join(", ")')
+          if [ "$job_count" = "0" ] || [ -n "$not_success" ]; then
+            echo "CI のジョブが成功していないため終了する（jobs: ${job_count} / 未成功: ${not_success:-なし}）"
+            exit 0
+          fi
+
+          pr=$(gh pr list \
+            --repo "$REPO" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --json number,headRefOid,labels,author \
+            --jq '.[0]')
+
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "ブランチ ${HEAD_BRANCH} に対応する open な PR が無いため終了する"
+            exit 0
+          fi
+
+          number=$(echo "$pr" | jq -r '.number')
+          author=$(echo "$pr" | jq -r '.author.login')
+          head_oid=$(echo "$pr" | jq -r '.headRefOid')
+          labeled=$(echo "$pr" | jq -r '[.labels[].name] | index("dependabot-auto-merge") != null')
+
+          if [ "$author" != "app/dependabot" ] && [ "$author" != "dependabot[bot]" ]; then
+            echo "#${number} は Dependabot の PR ではないため終了する（author: ${author}）"
+            exit 0
+          fi
+
+          if [ "$labeled" != "true" ]; then
+            echo "#${number} に dependabot-auto-merge ラベルが無いため終了する"
+            exit 0
+          fi
+
+          # CI が走った時点と PR の先頭コミットがずれている場合は、
+          # 新しいコミットに対する CI の完了を待つ
+          if [ "$head_oid" != "$HEAD_SHA" ]; then
+            echo "#${number} の先頭コミットが CI 実行時から変わっているため終了する"
+            echo "  CI: ${HEAD_SHA} / PR: ${head_oid}"
+            exit 0
+          fi
+
+          # base ブランチが動いているとマージが弾かれることがあるため数回試す。
+          # ここで失敗しても Dependabot が rebase すると CI が再実行され、
+          # この workflow がもう一度呼ばれるので取りこぼしにはならない。
+          for attempt in 1 2 3; do
+            if gh pr merge "$number" --repo "$REPO" --squash --delete-branch \
+              --match-head-commit "$HEAD_SHA"; then
+              echo "#${number} をマージした"
+              exit 0
+            fi
+            echo "マージに失敗した（${attempt} 回目）。20 秒後に再試行する"
+            sleep 20
+          done
+
+          echo "#${number} のマージに失敗した。Dependabot の rebase 後に再試行される"
+          exit 1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,123 @@
+# Dependabot の PR が自動マージしてよい内容かを判定し、該当すればラベルを付ける。
+# 実際のマージは CI 完了後に dependabot-auto-merge-complete.yml が行う。
+#
+# 判定を「PR が開いた時点」、マージを「CI が終わった時点」に分けているのは、
+# gh pr merge --auto が必須ステータスチェックの無いブランチでは CI の完了を待たず
+# その場でマージしてしまうため。
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  judge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot のメタデータを取得
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: 自動マージの可否を判定
+        id: judge
+        env:
+          DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_GROUP: ${{ steps.meta.outputs.dependency-group }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          set -euo pipefail
+
+          ok=false
+          reason="判定条件のいずれにも当てはまらないため"
+
+          if [ -n "$DEP_GROUP" ]; then
+            # グループ更新。dependabot.yml 側で minor / patch に限定しているグループのみ許可する
+            case "$DEP_GROUP" in
+              npm-development|composer-development|github-actions)
+                ok=true
+                reason="グループ ${DEP_GROUP} は minor / patch のみを含む設定のため"
+                ;;
+              *)
+                reason="グループ ${DEP_GROUP} は自動マージの対象に登録されていないため"
+                ;;
+            esac
+          elif [ -n "$UPDATE_TYPE" ]; then
+            # 単一パッケージの更新。依存の種類と更新レベルで判定する
+            level="${UPDATE_TYPE#version-update:semver-}"
+            case "$DEP_TYPE" in
+              direct:development)
+                if [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                  ok=true
+                  reason="開発依存の ${level} 更新のため"
+                else
+                  reason="開発依存だが ${level} 更新のため"
+                fi
+                ;;
+              indirect)
+                # Composer の推移的依存は vendor/ に入って配布されるうえ、
+                # fetch-metadata では本番依存から到達したものか判別できないため人が確認する。
+                if [ "$ECOSYSTEM" = "composer" ]; then
+                  reason="Composer の推移的依存は配布物に含まれ、依存元を判別できないため"
+                elif [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                  ok=true
+                  reason="推移的依存の ${level} 更新のため"
+                else
+                  reason="推移的依存だが ${level} 更新のため"
+                fi
+                ;;
+              direct:production)
+                if [ "$ECOSYSTEM" = "github-actions" ]; then
+                  # GitHub Actions は配布物に含まれないが、fetch-metadata は
+                  # direct:production を返すためここに来る。判断は開発依存と同じでよい。
+                  if [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                    ok=true
+                    reason="GitHub Actions の ${level} 更新のため"
+                  else
+                    reason="GitHub Actions だが ${level} 更新のため"
+                  fi
+                else
+                  # Font Awesome や Swiper など配布物に含まれるライブラリは
+                  # changelog への記載が必要なので人が確認する
+                  reason="配布物に含まれるライブラリの更新は changelog への記載が必要なため"
+                fi
+                ;;
+              *)
+                reason="依存の種類が判定できないため（dependency-type: ${DEP_TYPE:-空}）"
+                ;;
+            esac
+          else
+            # 複数パッケージをまとめた PR では update-type が取得できず、
+            # major 更新が混ざっていても見分けられないため人が確認する。
+            reason="複数パッケージをまとめた PR で更新レベルが判定できないため"
+          fi
+
+          echo "対象パッケージ: ${DEP_NAMES}"
+          echo "dependency-type: ${DEP_TYPE:-（なし）} / update-type: ${UPDATE_TYPE:-（なし）} / group: ${DEP_GROUP:-（なし）}"
+          echo "自動マージ: ${ok}（${reason}）"
+          echo "ok=${ok}" >> "$GITHUB_OUTPUT"
+
+      - name: 自動マージ対象のラベルを付ける
+        if: steps.judge.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh label create dependabot-auto-merge \
+            --repo "$REPO" \
+            --color 0e8a16 \
+            --description "CI 通過後に自動マージする Dependabot の PR" \
+            2>/dev/null || true
+          # gh pr edit --add-label は組織スコープ不足で失敗することがあるため REST API を使う
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            -X POST -f "labels[]=dependabot-auto-merge" --silent

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "7.4"
 		}
 	},
 	"require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee22aa11296e8828cf47c0f66563bd34",
+    "content-hash": "f9fd84ce16ee773b7c384bdc7b57c1d7",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
@@ -3070,5 +3070,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Refs vektor-inc/multi-repo-tasks#42（Dependabot の自動マージのしくみを各リポジトリへ展開する issue）

## 概要

Dependabot（依存ライブラリの更新 PR を自動で作る GitHub のしくみ）が作った PR のうち、安全と判断できるもの（開発用の依存の minor / patch 更新＝後方互換を保つ小さな更新、など）だけを、CI 通過後に人手なしでマージできるようにします。vk-blocks-pro で運用している構成（vektor-inc/vk-blocks-pro#3126 で導入した自動マージのしくみと、vektor-inc/vk-blocks-pro#3148 で直した「CI が 1 本の PR で何度も走る問題」の対策）をこのリポジトリに合わせて入れたものです。

登場するものは次の 4 つです。

| 名前 | 何をするものか |
|---|---|
| Dependabot（`.github/dependabot.yml`） | 毎週月曜に依存の更新 PR を作る。どのパッケージ管理を、どうまとめて更新するかはこの設定ファイルで指示する |
| judge（`Dependabot auto-merge` ワークフロー） | Dependabot の PR が開いた時点で、自動マージしてよい内容かを判定し、該当すれば `dependabot-auto-merge` ラベルを付ける |
| ゲート CI（既存の `PHP Unit Test` ワークフロー） | PHP 7.4 / 8.0 / 8.1 の 3 環境で PHPUnit を実行する。complete がマージの条件として見る |
| complete（`Dependabot auto-merge complete` ワークフロー） | ゲート CI の完了をきっかけに起動し、ラベル付きの PR を CI 成功後にマージする |

つながり方は次のとおりです。

```mermaid
flowchart LR
  dep["Dependabot<br>（更新 PR を作る）"] -- "PR が開く" --> judge["judge<br>（自動マージ可否を判定しラベル付け）"]
  dep -- "PR が開く" --> ci["ゲート CI: PHP Unit Test<br>（PHPUnit 3 環境）"]
  ci -- "完了イベント" --> complete["complete<br>（ラベル付き かつ CI 成功ならマージ）"]
```

judge（判定）と complete（マージ）を分けているのは、GitHub の自動マージ機能（`gh pr merge --auto`）が必須ステータスチェックの無いブランチでは CI を待たず即マージしてしまうためです。

## 何がどう変わるか

### 1. Dependabot の設定を追加（`.github/dependabot.yml`）

npm / Composer / GitHub Actions の 3 つのパッケージ管理について、毎週月曜 9:00（日本時間）に更新 PR を作ります。開発用の依存（ビルド・テスト用で配布物に入らないもの）の minor / patch 更新は 1 本の PR にまとめ（グループ名 `npm-development` / `composer-development` / `github-actions`）、本番依存（vendor/ に入って配布されるもの）と major 更新はグループに入らず個別の PR になります。

### 2. 自動マージするかどうかを判定する（`.github/workflows/dependabot-auto-merge.yml`）

Dependabot の PR が master 向けに開いたとき、Dependabot が PR に付けた情報（依存の種類・更新レベル・グループ名）を読み取り（`dependabot/fetch-metadata`）、次の表で判定します。自動マージ対象なら `dependabot-auto-merge` ラベルを付けます。判定結果と理由はワークフローのログに出ます。

| PR の内容 | 自動マージ | 理由 |
|---|---|---|
| グループ更新（`npm-development` / `composer-development` / `github-actions`） | する | `dependabot.yml` 側で minor / patch に限定しているため |
| 開発依存の単体更新（minor / patch） | する | 配布物に入らないため |
| 開発依存の単体更新（major） | しない | 破壊的変更の可能性があるため人が確認 |
| npm の推移的依存（依存の依存）の更新（minor / patch） | する | 配布物に入らないため |
| Composer の推移的依存の更新 | しない | vendor/ に入って配布されるうえ、本番依存から到達したものか判別できないため |
| GitHub Actions の単体更新（minor / patch） | する | 配布物に入らないため |
| 本番依存（Font Awesome・Swiper など配布物に含まれるライブラリ）の更新 | しない | changelog への記載が必要なため |
| 複数パッケージをまとめた PR（グループ以外） | しない | 更新レベルが判定できず major が混ざりうるため |

### 3. CI 通過後にマージする（`.github/workflows/dependabot-auto-merge-complete.yml`）

ゲート CI を既存の `PHP Unit Test`（`build_check.yml`）にしました。理由は、master に必須ステータスチェック `php unittest (7.4)` が設定されているためです。この設定がある以上、PHP Unit Test が通らない PR はそもそもマージできないので、別のゲート CI を新設しても意味がなく、PHP Unit Test 自体を Dependabot の PR で動かす必要があります（4 で対応）。

complete は `PHP Unit Test` の完了イベントで起動し、次をすべて満たすときだけマージ（squash＝PR のコミットを 1 つにまとめて取り込む方式）します。

- CI の実行（run）に含まれるジョブがすべて成功している（PHP 7.4 / 8.0 / 8.1 の 3 ジョブ全件。一部が skip された run は「テストしていない」と見なして弾く）
- PR の作者が Dependabot である
- PR に `dependabot-auto-merge` ラベルが付いている
- CI が走ったコミットと PR の先頭コミットが同じである（CI 後にコミットが積まれていたら次の CI を待つ）

### 4. Dependabot の PR で CI が走るようにする（`.github/workflows/build_check.yml` の条件変更）

これまで `PHP Unit Test` は `run-ci` ラベルを付けたときだけ動いていました。`php_unit` ジョブの実行条件を次のように変え、Dependabot の PR ではラベル無しでも動くようにしました。人が作った PR は従来どおり `run-ci` ラベルを付けたときだけ動きます。

```yaml
if: >-
  contains(github.event.pull_request.labels.*.name, 'run-ci') ||
  (github.event.pull_request.user.login == 'dependabot[bot]' &&
   github.event.action != 'labeled')
```

`labeled`（ラベルが付いたイベント）を Dependabot 側の条件から外しているのは、Dependabot が PR を作った直後に `dependencies` / `php` などのラベルを次々付けるため、そのたびに CI が起動して同じ内容を何度もテストしてしまうからです（vektor-inc/vk-blocks-pro#3148 で実際に 1 本の PR で CI が 5 回走った問題の対策）。Dependabot の PR は `opened` / `reopened` / `synchronize`（コミット追加）で動きます。ワークフロー全体の `types:` は変えていません（人が `run-ci` を付けたときの起動に `labeled` が必要なため）。

### 5. composer.json に対象 PHP を明示（`config.platform.php`）

Dependabot は PHP 8 の環境で `composer update` を実行するため、対象 PHP を明示していないと PHP 8 必須のパッケージが composer.lock に入り、PHP 7.4 の CI が落ちます（vk-blocks-pro で実際に起きました）。`composer.json` の `config` に `"platform": { "php": "7.4" }`（依存解決のときに PHP 7.4 で動く前提で計算させる設定）を追加しました。値は `style.css` の `Requires PHP: 7.4` と CI マトリクスの下限に合わせています。

composer.lock は `composer update --lock --no-install` でハッシュ（`content-hash`）と `platform-overrides` だけ更新しており、**パッケージのバージョンは 1 つも変わっていません**。`composer validate --no-check-publish` も通っています。

## 判断が分かれる点

- **base が進んだときの再実行**: master には「Require branches to be up to date」（strict。base の最新を取り込んでいない PR はマージ不可）も有効です。そのため Dependabot の PR が開いてから master に別の PR がマージされると、Dependabot の PR は out-of-date になり、complete の `gh pr merge` が弾かれます。ただし Dependabot は必須チェックで up-to-date が要求されている場合に自分で rebase するので、rebase 後（`synchronize`）に `PHP Unit Test` が再実行され、その完了で complete がもう一度呼ばれてマージされます。complete 側も 3 回のマージ再試行と「失敗しても rebase 後に再実行される」前提で作られているため、取りこぼしにはなりませんが、Dependabot の PR が複数同時に開いていると、1 本マージされるたびに残りの PR で PHPUnit（3 環境）が走り直します。Actions の実行時間が気になる場合は `dependabot.yml` の `open-pull-requests-limit`（同時に開く PR の上限。今は 5）を下げる余地があります。
- **ゲート CI が重い**: `PHP Unit Test` は wp-env（Docker で WordPress を立ち上げる開発環境）を起動して 3 環境で PHPUnit を回すため、Dependabot の PR 1 本あたり数十分かかります。上記の必須ステータスチェックの都合で軽量な Dependabot CI を別に新設しても代わりにならないため、既存 CI をそのまま使う判断にしました。

## 気づいた点（この PR では変更しない）

- `build_check.yml` の `actions/setup-node@v1` は古いメジャーバージョンです。GitHub Actions の Dependabot 更新が有効になると、この更新 PR は major 更新のため自動マージ対象にはならず、人の確認に回ります。
- `build_check.yml` の `on.pull_request.branches` に `develop` が含まれていますが、judge（`dependabot-auto-merge.yml`）は master 向けの PR だけを対象にしています。`dependabot.yml` に `target-branch`（更新 PR の向き先ブランチを指定する項目）の指定は無いのでデフォルトブランチ（master）向けにしか PR は作られず、実害はありません。

## 確認手順

1. 本 PR の変更ファイルの YAML が読める形であること（CI は Dependabot の PR でしか動かないため、本 PR 上では動作しない）
   - 手元で確認済み: `python3 -c 'import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print("ok")'` で 4 ファイルとも `ok`
   - `dependabot-auto-merge-complete.yml` の `workflows:` の値 `"PHP Unit Test"` が `build_check.yml` の `name:` と一致していること
2. マージ後、Dependabot の自動 PR 作成（security updates）を有効化する（司が行う）
3. 最初に作られた Dependabot の PR で以下を確認する
   - `Dependabot auto-merge` ワークフローのログに判定結果と理由が出ている
   - 自動マージ対象なら `dependabot-auto-merge` ラベルが付いている
   - ゲート CI（`PHP Unit Test`）が `run-ci` ラベル無しで動いている。かつ、Dependabot がラベルを付けるたびには起動していない（Actions の一覧で同じ PR の run が 1 回であること）
   - CI 成功後に `Dependabot auto-merge complete` が動き、PR がマージされている
4. 人が作った PR では従来どおり `run-ci` ラベルを付けない限り `PHP Unit Test` が動かないこと（本 PR 自体が該当。ラベルを付けない状態で `PHP Unit Test` が skip されていることを Checks で確認する）

@coderabbitai ignore
