### PR TITLE
[ 開発環境 ] 必須ステータスチェックがラベル付与時の skip run で待機中のままになり、自動マージ対象の Dependabot の PR がマージされない問題を修正

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -6,20 +6,27 @@ on:
       - master
       - develop
     types: [opened, reopened, labeled, synchronize]
+
+# 同じ PR に対する run は 1 つだけ残し、古い run は取り消す。
+# Dependabot は PR 作成直後に dependencies / php などのラベルを次々付け、
+# そのたびに run が作られるため、取り消さないと同じ内容を何度もテストしてしまう。
+concurrency:
+  group: php-unit-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   php_unit:
     name: php unittest
     # Dependabot の PR は run-ci ラベル無しでも実行する。
     # dependabot-auto-merge-complete.yml がこの結果を見てマージするため。
     #
-    # ただし labeled のときは動かさない。Dependabot は PR を作った直後に
-    # dependencies / php などのラベルを次々付けるため、そのたびに
-    # CI が起動して同じ内容を何度もテストしてしまう。
-    # 人が run-ci ラベルを付けた場合は上の条件で拾われる。
+    # labeled のときも除外しない。master の必須ステータスチェック「php unittest (7.4)」は
+    # このワークフローの最新の run で判定されるため、Dependabot がラベルを付けたときの run を
+    # skip にすると、成功した run があっても最新 run に該当ジョブが無く「待機中」のまま
+    # マージできなくなる。重複起動は上の concurrency で古い run を取り消して抑える。
     if: >-
       contains(github.event.pull_request.labels.*.name, 'run-ci') ||
-      (github.event.pull_request.user.login == 'dependabot[bot]' &&
-       github.event.action != 'labeled')
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Refs https://github.com/vektor-inc/multi-repo-tasks/issues/42（Dependabot の自動マージのしくみを各リポジトリへ展開する issue）

## 概要

#1424（Dependabot の PR を CI 通過後に自動マージするしくみの導入）のあと、自動マージ対象と判定された PR（#1423 / #1425 / #1435）が `PHP Unit Test` に成功しているのにマージされず、マージ処理のログに「the base branch policy prohibits the merge（base ブランチの保護ルールがマージを禁止している）」が出ていました。

master には必須ステータスチェック `php unittest (7.4)` が設定されています。GitHub はこのチェックを **同じコミットに対する `PHP Unit Test` の最新の run** で判定します。#1424 では、Dependabot がラベルを付けたとき（`labeled` イベント）の起動を skip にしていたため、テストに成功した run のあとに「ジョブが 1 つも無い skip の run」が 4 つ並び、最新 run に `php unittest (7.4)` が存在せず「待機中」のままになっていました。

## 何がどう変わるか

- `labeled` でも Dependabot の PR は実行対象にしました（skip しない）
- 同じ PR に対する run を 1 つに絞る `concurrency`（同じグループの古い run を取り消す設定）を追加しました。Dependabot がラベルを 4 回付けても、途中の run は取り消され、最後の run だけがテストを完了します。取り消された run は `Dependabot auto-merge complete` の条件（成功のみ）に当たらないので、誤ってマージされることはありません

人が `run-ci` ラベルを付けたときの動きは変わりません。人の PR に push を重ねた場合は、進行中の古い run が取り消されて最新のコミットだけがテストされるようになります。

## 確認手順

1. マージ後、open の Dependabot PR で `@dependabot recreate` を実行する
2. `PHP Unit Test` の run が PR ごとに 1 つ完了し、途中の run は cancelled になっていること
3. `dependabot-auto-merge` ラベルの付いた PR が `Dependabot auto-merge complete` でマージされること

@coderabbitai ignore
