### PR TITLE
[ G2/G3 ][ その他 ] サイドバーの子ページ一覧・カテゴリー一覧の呼び出しを、WordPress が警告対象にしようとしているクエリ文字列形式から配列形式へ変更

### DIFF
--- a/_g2/sidebar-page.php
+++ b/_g2/sidebar-page.php
@@ -18,7 +18,13 @@ if ( is_active_sidebar( $widdget_area_name ) ) {
 	} // if($post->ancestors){
 
 	if ( $post_id ) {
-		$children = wp_list_pages( 'title_li=&child_of=' . $post_id . '&echo=0' );
+		$children = wp_list_pages(
+			array(
+				'title_li' => '',
+				'child_of' => $post_id,
+				'echo'     => false,
+			)
+		);
 		if ( $children ) { ?>
 			<aside class="widget widget_child_page widget_link_list">
 			<nav class="localNav">

--- a/_g2/sidebar-post.php
+++ b/_g2/sidebar-post.php
@@ -56,7 +56,7 @@ while ( $post_loop->have_posts() ) :
 <nav class="localNav">
 <h1 class="subSection-title"><?php _e( 'Category', 'lightning' ); ?></h1>
 <ul>
-	<?php wp_list_categories( 'title_li=' ); ?>
+	<?php wp_list_categories( array( 'title_li' => '' ) ); ?>
 </ul>
 </nav>
 </aside>

--- a/_g3/template-parts/sidebar-contents-page.php
+++ b/_g3/template-parts/sidebar-contents-page.php
@@ -26,7 +26,13 @@ if ( $post->ancestors ) {
 }
 
 if ( $ancestor_post_id ) {
-	$children = wp_list_pages( 'title_li=&child_of=' . $ancestor_post_id . '&echo=0' );
+	$children = wp_list_pages(
+		array(
+			'title_li' => '',
+			'child_of' => $ancestor_post_id,
+			'echo'     => false,
+		)
+	);
 	if ( $children ) { ?>
 			<aside class="widget widget_link_list">
 			<h4 class="sub-section-title"><a href="<?php echo esc_url( get_permalink( $ancestor_post_id ) ); ?>"><?php echo get_the_title( $ancestor_post_id ); ?></a></h4>

--- a/_g3/template-parts/sidebar-contents-post.php
+++ b/_g3/template-parts/sidebar-contents-post.php
@@ -71,7 +71,7 @@ endwhile;
 <aside class="widget widget_link_list">
 <h4 class="sub-section-title"><?php _e( 'Category', 'lightning' ); ?></h4>
 <ul>
-	<?php wp_list_categories( 'title_li=' ); ?>
+	<?php wp_list_categories( array( 'title_li' => '' ) ); ?>
 </ul>
 </aside>
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,8 @@ vk-develop@vektor-inc.co.jp
 
 [ G3 ][ Design Bug Fix ] Rewrite the blog card media query left in the old syntax with range syntax, so the blog card no longer switches to the image-beside-text layout at exactly 576px wide while the rest of the theme treats that width as mobile
 
+[ G2/G3 ][ Other ] Rewrite the wp_list_pages() / wp_list_categories() calls in the sidebar page and category list templates to use array arguments instead of query strings, with no change to the output
+
 v15.39.1
 [ G2/G3 ][ Bug Fix ] Fix the bundled Bootstrap 4 responsive classes (.col-md-*, .d-md-none, .navbar-expand-md, spacing utilities and so on) switching one step earlier than the rest of the theme at exactly 576 / 768 / 992 / 1200px, by rewriting the Bootstrap breakpoint mixins to range syntax
 


### PR DESCRIPTION
Closes #1438

@coderabbitai ignore

## 概要

サイドバーに子ページ一覧とカテゴリー一覧を出している 4 か所で、WordPress の一覧出力関数（`wp_list_pages()` = 子ページの一覧を `<li>` で出力する関数、`wp_list_categories()` = カテゴリーの一覧を `<li>` で出力する関数）に渡す引数を、**クエリ文字列形式**（URL の `?` の後ろと同じ `key=value&key=value` という 1 本の文字列）から**配列形式**へ書き換えました。

**表示・出力される HTML は変わりません。**

## 背景

WordPress コアの Trac チケット [#66049](https://core.trac.wordpress.org/ticket/66049)（Trac は WordPress コアの不具合・提案を管理する掲示板）で、これらの関数にクエリ文字列形式で引数を渡す使い方に対して `_doing_it_wrong()`（開発者向けに「この使い方は推奨されない」と通知する仕組み。デバッグ表示を有効にしていると画面やログに出る）を出す案が挙がっています。そのチケットの調査結果の中で、今もクエリ文字列形式を使っているテーマとして **Lightning が名指し**されていました。

チケットはまだ提案段階ですが、コアがこの通知を入れた場合、Lightning を使っているサイトでデバッグ表示を有効にすると、該当箇所からこの通知が出るようになります。書き換えは機械的で挙動も変わらないため、先に対応しました。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `_g3/template-parts/sidebar-contents-page.php` | `wp_list_pages( 'title_li=&child_of=' . $ancestor_post_id . '&echo=0' )` | `wp_list_pages( array( 'title_li' => '', 'child_of' => $ancestor_post_id, 'echo' => false ) )` |
| `_g3/template-parts/sidebar-contents-post.php` | `wp_list_categories( 'title_li=' )` | `wp_list_categories( array( 'title_li' => '' ) )` |
| `_g2/sidebar-page.php` | `wp_list_pages( 'title_li=&child_of=' . $post_id . '&echo=0' )` | `wp_list_pages( array( 'title_li' => '', 'child_of' => $post_id, 'echo' => false ) )` |
| `_g2/sidebar-post.php` | `wp_list_categories( 'title_li=' )` | `wp_list_categories( array( 'title_li' => '' ) )` |

G3 は現行世代のテンプレート、G2 は旧世代のテンプレートで、同じ 2 パターンが両方にあります。

### なぜ表示が変わらないか

WordPress コア側の実装（`wp-includes/post-template.php` / `category-template.php` / `post.php`）まで突き合わせて確認しています。

| 引数 | 変更前に渡っていた値 | 変更後に渡す値 | コア側の扱い |
|---|---|---|---|
| `title_li` | `''`（クエリ文字列を分解した結果の空文字） | `''` | 値があるときだけ見出し行 `<li class="pagenav">` を出す判定。どちらも空なので見出し行は出ない |
| `echo` | `'0'`（文字列） | `false` | 値が偽なら出力せず文字列を返す。PHP では文字列 `'0'` も `false` も偽 |
| `child_of` | `'123'` のような文字列 | 整数（`$post_id` / `$ancestor_post_id`） | `get_pages()` の内部で整数へ変換される |

`wp_list_pages()` の戻り値の型（文字列）も変わらないため、子ページが無いときにサイドバーの枠自体を出さない `if ( $children )` の分岐も変更前と同じに動きます。

## 確認手順

### 前提条件

- 親ページと、その配下の子ページを 2 件以上作成しておく
- 子ページを 1 件も持たない固定ページを 1 件作成しておく
- 投稿を 1 件以上作成し、カテゴリーを 2 件以上作成して割り当てておく
- 外観 > カスタマイズ > デザイン設定で、G3 のスキンと G2 のスキン（Origin II など）の両方を切り替えて確認する

### 手順

#### 1. 固定ページのサイドバーの子ページ一覧（G3）

1. 子ページを持つ親ページを公開側で開く
   → ✓ サイドバーに子ページ一覧のブロックが出て、親ページのタイトルが見出しになっている
   → ✓ 一覧の先頭に「固定ページ」といった余分な見出し行（`<li class="pagenav">`）が**入っていない**
2. 子ページを開く
   → ✓ 同じ親ページ配下の子ページ一覧が、上と同じ内容で出る
3. ブラウザの検証ツールでサイドバーの HTML を確認する
   → ✓ `master` ブランチで同じページを開いたときと HTML が一致する

#### 2. 子ページを持たない固定ページ（G3）

1. 子ページを 1 件も持たない固定ページを公開側で開く
   → ✓ サイドバーに子ページ一覧の枠（`.widget_link_list`）自体が**出ない**

#### 3. 投稿のサイドバーのカテゴリー一覧（G3）

1. 投稿を公開側で開く
   → ✓ サイドバーに「Category」見出しのカテゴリー一覧が出る
   → ✓ 一覧の項目・並び・件数が変更前と同じ
   → ✓ 一覧の先頭に「カテゴリー」といった余分な見出し行が入っていない

#### 4. G2 でも同じ確認をする

1. 外観 > カスタマイズ > デザイン設定で、G2 のスキン（Origin II など）へ切り替える
2. 上記 1〜3 と同じ確認を行う
   → ✓ G3 と同様に、変更前と同じ内容・同じ HTML で出る

### デグレ確認

- 上記のいずれの画面でも、PHP の警告・通知（Notice / Warning）が新たに出ないこと
- `WP_DEBUG` を有効にした状態で各ページを開き、エラーログに新規の出力が無いこと

## スクリーンショット

表示・出力 HTML に影響しない内部的な引数の書き方の変更のため、省略します（上記「確認手順」の手順 1-3 と 4 で、変更前後の HTML が一致することを確認する形にしています）。

## レビュー状況

- 🔒 セキュリティレビュー（安藤）: PASS
- 🎨 UX レビュー（植草）: PASS

詳細は #1438 のコメントを参照してください。

## 関連

- WordPress Trac [#66049](https://core.trac.wordpress.org/ticket/66049)
- vektor-inc/lightning-pro#411（Lightning Pro のサイドバーで同じ書き換えを行う issue）
- vektor-inc/vk-all-in-one-expansion-unit#1487（ExUnit の子ページリストウィジェットで同じ書き換えを行う issue）

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/862