### PR TITLE
[ 開発環境 ] npm run dist で配布物に .DS_Store が混入し、WordPress.org へのアップロードで弾かれる問題を修正

### DIFF
--- a/copy-files.js
+++ b/copy-files.js
@@ -20,6 +20,13 @@ const filesToCopy = [
   "./_g3/assets/**",
 ];
 
+// macOS の Finder が作るファイル。配布物に混ざると WordPress.org へのアップロードで弾かれる。
+// glob は dot ファイルを列挙しないため excludedPaths では止まらず、ディレクトリごとコピーする
+// fs.copy 側の filter で除外する。
+const excludedFileNames = [".DS_Store", "._.DS_Store"];
+
+const copyFilter = (src) => !excludedFileNames.includes(path.basename(src));
+
 const excludedPaths = [
   "./_g2/assets/css/map/**",
   "./_g3/node_modules/**/*.*",
@@ -42,7 +49,7 @@ async function copyFiles() {
       const files = glob.sync(file, { ignore: excludedPaths });
       for (const src of files) {
         const dest = path.join(destination, path.relative('.', src));
-        await fs.copy(src, dest);
+        await fs.copy(src, dest, { filter: copyFilter });
         console.log(`Copied ${src} to ${dest}`);
       }
     }


### PR DESCRIPTION
@coderabbitai ignore

## 概要

`npm run dist` で作る配布物（`dist/`）に macOS の `.DS_Store` が混入し、WordPress.org へアップロードする際に弾かれていた問題を修正します。

## 原因

`copy-files.js` には既に `excludedPaths`（コピーから除外するパスのリスト）がありますが、**ここに `.DS_Store` を足しても止まりません。**

コピー対象を列挙している `glob`（パターンでファイルを探すライブラリ）は、`.` で始まる隠しファイルを既定では列挙しません。そのため `.DS_Store` はそもそも `excludedPaths` の判定対象に乗っていませんでした。

実際の混入経路は別で、`./inc/**` や `./_g3/assets/**` のような指定では **ディレクトリ自身**（`inc`、`_g3/assets`）も列挙されます。それを `fs.copy()` がディレクトリごと再帰的にコピーする際に、中にある `.DS_Store` が一緒に運ばれていました。

```js
const files = glob.sync(file, { ignore: excludedPaths });
for (const src of files) {
  // src が "inc"（ディレクトリ自身）のとき、中の .DS_Store ごとコピーされる
  await fs.copy(src, dest);
}
```

## 変更内容

`fs.copy()` の `filter`（コピーするかどうかを 1 ファイルずつ判定する関数）で `.DS_Store` と `._.DS_Store` を除外します。ディレクトリを再帰コピーする途中の各ファイルに対しても呼ばれるため、この経路を塞げます。

```js
const excludedFileNames = [".DS_Store", "._.DS_Store"];
const copyFilter = (src) => !excludedFileNames.includes(path.basename(src));

// ...
await fs.copy(src, dest, { filter: copyFilter });
```

`._.DS_Store` も併せて除外しているのは、`.gitignore` が既にこの 2 つを対象にしているのに合わせたためです。

## なぜ今まで GitHub Release の zip では問題にならなかったか

GitHub Actions は Linux 上でビルドしており、`.DS_Store` がそもそも生成されないためです。実際、Release 15.40.0 の `lightning.zip` を展開して確認しましたが混入は 0 件でした。

**手元の Mac で `npm run dist` して手動で SVN へアップロードする経路でのみ発生します。** WordPress.org 配信のテーマは SVN へ手動アップロードする運用のため、この経路が実害になっていました。

## 確認手順

### 前提条件

- macOS であること（`.DS_Store` が生成される環境）
- リポジトリ内に `.DS_Store` が存在すること。無ければ Finder で `inc/` や `_g3/assets/` を一度開くと作られる

```bash
# 存在確認（1件以上あればOK）
find . -name ".DS_Store" -not -path "./node_modules/*" -not -path "./vendor/*" | head
```

### Before（修正前の再現手順）

1. このブランチではなく `master` をチェックアウトする
2. `node copy-files.js` を実行する
3. 生成物を確認する
   ```bash
   find dist -name ".DS_Store"
   ```
   → ✗ `dist/lightning/inc/.DS_Store` などが複数ヒットする

### After（修正後）

1. このブランチ `fix/exclude-ds-store-from-dist` をチェックアウトする
2. `rm -rf dist && node copy-files.js` を実行する
3. 生成物を確認する
   ```bash
   find dist \( -name ".DS_Store" -o -name "._.DS_Store" \)
   ```
   → ✓ 1 件もヒットしない

### デグレ確認（消しすぎていないこと）

修正前後の `dist` のファイル一覧を突き合わせ、`.DS_Store` 以外が減っていないことを確認する。

```bash
# 修正前後それぞれで実行して比較
( cd dist && find . -type f | LC_ALL=C sort )
```

→ ✓ 減っているのは `.DS_Store` 9 件のみ（本 PR の作成時に実測。他のファイルは 1 件も減っていない）

## スクリーンショット

ビルドスクリプトの変更で画面表示に影響しないため、省略します。

## 関連

`readme.txt` の changelog には追記していません。`[ 開発環境 ]` に該当する変更で、WordPress.org 配信の `readme.txt` には開発環境エントリを記載しない運用のためです。
