### PR TITLE
[ 開発環境 ] 配布物に vendor 配下の開発用ファイルが混入し、WordPress.org のアップロードで弾かれる問題を修正

### DIFF
--- a/copy-files.js
+++ b/copy-files.js
@@ -20,12 +20,44 @@ const filesToCopy = [
   "./_g3/assets/**",
 ];
 
-// macOS の Finder が作るファイル。配布物に混ざると WordPress.org へのアップロードで弾かれる。
-// glob は dot ファイルを列挙しないため excludedPaths では止まらず、ディレクトリごとコピーする
-// fs.copy 側の filter で除外する。
+// 配布物に含めないファイル。WordPress.org のアップロード時に走る自動レビューが
+// 読めない形式のファイルを含んでいると弾かれるため、コピー段階で落とす。
+// glob は dot ファイルを列挙せず、ディレクトリ自身が列挙されて丸ごとコピーされる経路が
+// あるため、excludedPaths では止まらない。fs.copy 側の filter で除外する。
+
+// macOS の Finder が作るファイル。
 const excludedFileNames = [".DS_Store", "._.DS_Store"];
 
-const copyFilter = (src) => !excludedFileNames.includes(path.basename(src));
+// 開発専用の設定ファイル。vendor 配下のライブラリが同梱してくるもので、実行には不要。
+const excludedDevFileNames = ["phpunit.xml.dist", "phpunit.xml", "composer.lock"];
+
+// 開発専用のディレクトリ。配下ごと除外する。
+const excludedDirNames = [".github", ".vscode", ".circleci"];
+
+const isExcluded = (src) => {
+  const base = path.basename(src);
+
+  if (excludedFileNames.includes(base)) {
+    return true;
+  }
+
+  // ディレクトリ自身と、その配下のファイルの両方を落とす。
+  const segments = src.split(path.sep);
+  if (segments.some((segment) => excludedDirNames.includes(segment))) {
+    return true;
+  }
+
+  // vendor 配下に限り、開発用の dot ファイル（.gitignore / .phpcs.xml / .eslintrc.js 等）と
+  // 開発専用の設定ファイルを除外する。テーマ本体側の dot ファイルは対象にしない。
+  const isInVendor = segments.includes("vendor");
+  if (isInVendor && (base.startsWith(".") || excludedDevFileNames.includes(base))) {
+    return true;
+  }
+
+  return false;
+};
+
+const copyFilter = (src) => !isExcluded(src);
 
 const excludedPaths = [
   "./_g2/assets/css/map/**",


### PR DESCRIPTION
@coderabbitai ignore

## 概要

`npm run dist` で作る配布物に `vendor/` 配下のライブラリが同梱している開発専用ファイルが入り、WordPress.org へのアップロードが弾かれていた問題を修正します。

実際に出ていたメッセージ:

> The theme contains 40 files that the automated review cannot read: vendor/vektor-inc/font-awesome-versions/.eslintignore, ... and 30 more. Remove them and upload the theme again.

WordPress.org のアップローダーが走らせる自動レビューが、`.eslintrc.js` / `.mjs` / `.yml` のような「レビュー用のスクリプトが読めない形式」のファイルを検出して弾いています。

## 原因

`copy-files.js` は `./vendor/**` をコピー対象にしています。`composer install --no-dev` は開発用**パッケージ**は除きますが、インストールされた各パッケージが自分のリポジトリに置いている開発用ファイル（CI 設定・lint 設定など）はそのまま入ります。

該当は `vendor/vektor-inc/` 配下の 8 パッケージ（font-awesome-versions / vk-breadcrumb / vk-color-palette-manager / vk-component / vk-css-optimize / vk-helpers / vk-swiper / vk-term-color）で、次のようなファイルです。

```
.github/workflows/*.yml   .gitignore      .phpunit.xml      .prettierignore
.github/scripts/*.mjs     .gitattributes  phpunit.xml.dist  .coderabbit.yaml
.eslintrc.js              .phpcs.xml      .wp-env.json      composer.lock
```

いずれもライブラリの実行には不要です（`.htaccess` のような実行時に必要な dot ファイルは vendor 配下に存在しないことを確認済み）。

**これは今回入り込んだものではありません。** 15.39.1 の配布 zip にも同じファイルが同じサイズで入っており、以前から同梱されていました。

## 変更内容

前の PR #1440 で `.DS_Store` を止めるために入れた `fs.copy()` の `filter`（1 ファイルずつコピー可否を判定する関数）を拡張します。

- `.github` / `.vscode` / `.circleci` ディレクトリを**配下ごと**除外
- **`vendor/` 配下に限り**、dot ファイル（`.gitignore` / `.phpcs.xml` / `.eslintrc.js` 等）を除外
- `phpunit.xml.dist` / `phpunit.xml` / `composer.lock` を除外

dot ファイルの除外を `vendor/` 配下に限定しているのは、テーマ本体側の dot ファイルを巻き込まないためです（現状テーマ本体から配布物へ入る dot ファイルは 0 件ですが、将来必要なものが増えたときに勝手に消えないようにしています）。

## 確認手順

### 前提条件

```bash
# vendor が無ければ用意する
composer install
```

### Before（修正前の再現手順）

1. `master` をチェックアウトする
2. `rm -rf dist && node copy-files.js` を実行する
3. 開発用ファイルが入っていることを確認する
   ```bash
   find dist \( -path "*/.github/*" -o \( -path "*/vendor/*" -name ".*" \) \) | wc -l
   ```
   → ✗ 49 件ヒットする

### After（修正後）

1. このブランチ `fix/exclude-vendor-dev-files-from-dist` をチェックアウトする
2. `rm -rf dist && node copy-files.js` を実行する
3. 同じコマンドで確認する
   → ✓ 0 件

### デグレ確認（ライブラリを壊していないこと）

1. `vendor` 配下の PHP ファイルが 1 つも消えていないこと
   ```bash
   find dist/lightning/vendor -name "*.php" | wc -l
   ```
   → ✓ 45 件（修正前後で同数）
2. Composer のオートローダー（クラスを自動で読み込む仕組み）一式が残っていること
   ```bash
   ls dist/lightning/vendor/composer/
   ```
   → ✓ `autoload_real.php` / `autoload_static.php` / `ClassLoader.php` などが揃っている
3. 修正前後の `dist` のファイル一覧を突き合わせる
   ```bash
   ( cd dist && find . -type f | LC_ALL=C sort )
   ```
   → ✓ 減っているのは上記の開発用ファイル 49 件のみ。`.php` は 1 件も減っていない（本 PR の作成時に実測）

## スクリーンショット

ビルドスクリプトの変更で画面表示に影響しないため、省略します。

## 関連

- #1440（同じ `filter` で `.DS_Store` の混入を止めた PR）
- 各ライブラリ側の `.gitattributes` に `export-ignore` を設定して、Composer が取得する時点で除外する根本対応は、対象 8 リポジトリへ別途 issue を立てて進めます。本 PR は Lightning 側で先に塞ぐものです。

`readme.txt` の changelog には追記していません。`[ 開発環境 ]` に該当する変更で、WordPress.org 配信の `readme.txt` には開発環境エントリを記載しない運用のためです。
