### PR TITLE
[ 仕様変更 ] WordPress 6.5 で編集画面のデザイン設定パネルが表示されないため、動作要件を 6.6 以上に引き上げ

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,7 +27,7 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<!-- style.css の Requires at least に合わせる. -->
-	<config name="minimum_supported_wp_version" value="6.5"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ vk-develop@vektor-inc.co.jp
 
 == Changelog ==
 
+[ Spec Change ] Raise the minimum required WordPress version from 6.5 to 6.6, because the Lightning design setting panel in the block editor sidebar does not appear on WordPress 6.5
+
 v15.40.0
 [ G2 ][ Spec Change ] Widen the horizontal padding of buttons and input fields to match Lightning Pro, on sites using a bs4 design skin such as Origin II
 [ G3 ][ Spec Change ] Style submit buttons written as button elements inside forms like input[type="submit"], so submit and back buttons output by form plugins such as Snow Monkey Forms no longer use browser default styles. Disabled submit buttons now show a not-allowed cursor.

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Description: Lightning is a very simple & easy to customize theme which is based
 Author: Vektor,Inc.
 Author URI: https://www.vektor-inc.co.jp
 Version: 15.40.0
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 7.4
 Tags: blog, one-column, custom-background, custom-colors, custom-logo, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, sticky-post, theme-options, threaded-comments, translation-ready, block-styles, wide-blocks


### PR DESCRIPTION
Closes #1446

## 概要

Lightning が動作対象として宣言している WordPress の最低バージョン（`style.css` の `Requires at least`）を、6.5 から 6.6 へ引き上げます。

投稿編集画面のサイドバーに出る「Lightning デザイン設定」パネルが WordPress 6.5 では表示されず、投稿ごとのレイアウト設定などが行えない状態でした。#1446（WordPress 6.5 でデザイン設定パネルが表示されない不具合の issue）で挙げた 2 案のうち、動作要件を引き上げる案を採用しています。

## なぜ 6.5 で表示されないのか

パネルは `PluginDocumentSettingPanel`（ブロックエディターのサイドバーに独自の設定パネルを追加するための WordPress 標準の画面部品）を使って描画しています。この部品がどのスクリプトから提供されるかが WordPress 6.6 で変わりました。

| WordPress のバージョン | `wp.editPost` から取得 | `wp.editor` から取得 |
|---|---|---|
| 6.5 | できる | **できない** |
| 6.6 以降 | できる（非推奨） | できる |

Lightning のパネル用スクリプト（`_g2/assets/_js/design-setting-panel.js` と `_g3/assets/_js/design-setting-panel.js` の 2 行目）は `wp.editor` 側から取得しているため、WordPress 6.5 では部品が取れず、パネルが 1 つも描画されませんでした。

コード側で 6.5 にも対応させる案（`wp.editor` に無ければ `wp.editPost` を使う切り替えを入れる）もありましたが、6.5 は既にサポート対象として古く、`wp.editPost` は 6.6 以降で非推奨になっているため、動作要件を上げる方を選んでいます。

## 変更内容

| ファイル | 変更 |
|---|---|
| `style.css` | `Requires at least` を `6.5` → `6.6` |
| `.phpcs.xml.dist` | PHPCS（コーディング規約チェックツール）が「この WordPress バージョン以降を前提に検査する」ために見る設定 `minimum_supported_wp_version` を `6.5` → `6.6`。`style.css` の値に合わせるものだとファイル内のコメントで指定されているため |
| `readme.txt` | changelog へ 1 行追記 |

コードの動作そのものは変更していません。

## 確認手順

### 変更したファイルの確認

1. `style.css` の 9 行目が `Requires at least: 6.6` になっていること
2. `.phpcs.xml.dist` の 30 行目が `<config name="minimum_supported_wp_version" value="6.6"/>` になっていること
3. `readme.txt` の `== Changelog ==` の直後（`v15.40.0` の見出しより上）に、動作要件引き上げの 1 行が入っていること

→ 3 点とも上記のとおりになっていれば OK です。

### PHPCS に新しい指摘が出ていないこと

最低バージョンを上げると、「6.6 で非推奨になった関数を使っている」といった指摘が新たに出る可能性があるため、引き上げ前後で件数を比べました。

```
composer install
vendor/bin/phpcs -q --report=summary
```

→ 引き上げ前（6.5）・引き上げ後（6.6）ともに `2764 ERRORS AND 591 WARNINGS`（151 ファイル）で、**件数・内容ともに変化なし**でした。既存の指摘は今回の変更とは無関係のものです。

### WordPress 6.6 以降で従来どおり動くこと

1. WordPress 6.6 以降の環境で Lightning を有効化する
2. 投稿の新規追加画面を開く
3. 右サイドバーの「投稿」タブを表示する

→ 「Lightning デザイン設定」パネルが表示され、レイアウト（2カラム／1カラム など）を変更して保存できること。ブラウザの開発者ツールのコンソールに新しいエラー・警告が出ていないこと。

## 調査の経緯（参考）

この不具合は、vektor-inc/lightning-pro#413（Lightning Pro 8.28 で編集画面の設定パネルが消え、「未登録の依存関係とともにキューへ追加されました: react/jsx-dev-runtime」という Notice が出る不具合）と同じことが Lightning でも起きないか確認する中で見つかりました。

**#413 と同一の原因（ビルドで使う Babel のバージョンが上がり、依存スクリプトの一覧に WordPress 側が登録していない名前が混ざる）は、Lightning では発生しません。** 次を確認済みです。

- Lightning のパネル用スクリプトは JSX（JavaScript の中に HTML のようなタグを書く記法）を使わず、画面部品を組み立てる関数 `wp.element.createElement` を直接呼んでいるため、JSX を変換する Babel の設定（`@babel/preset-react`）自体を使っていない
- 依存スクリプトの一覧を自動生成する仕組み（`DependencyExtractionWebpackPlugin`。ビルド時に `*.asset.php` を出力する webpack プラグイン）を使っておらず、依存は PHP に直接書かれている。リポジトリ内に `*.asset.php` は 1 つも無い
- 現在の master（`a7a6ab76`）で `npm install` してビルドし直したところ、生成物はコミット済みのファイルと完全に一致した
- ビルドに使う Babel を 8 系（`@babel/core` 8.0.1 / `@babel/preset-env` 8.0.2 / `babel-loader` 10）へ上げてビルドしても、パネル用スクリプトの生成物は変化せず、`react/jsx-dev-runtime` は出力されなかった

@coderabbitai ignore
