### PR TITLE
[ G2 ][ デザイン不具合修正 ] ブロックエディターのスキン CSS が管理画面全体へ漏れて「メニューを閉じる」ボタンの文字が折り返される不具合を修正

### DIFF
--- a/_g2/inc/class-design-manager.php
+++ b/_g2/inc/class-design-manager.php
@@ -491,6 +491,22 @@ class Lightning_Design_Manager {
 	 * この関数が追加する CSS は管理画面本体の <body class="wp-admin"> には構造的に
 	 * 到達しない。
 	 *
+	 * なお _g2/functions.php の lightning_load_common_editor_css_to_gutenberg() は、
+	 * 引き続き enqueue_block_assets 経由で assets/css/common_editor.css を管理画面本体にも
+	 * 出し続けているが、これは意図した状態である。同 CSS の裸の body { ... } 規則は
+	 * --vk-width-editor-sidebar 等のカスタムプロパティ定義のみで、font-size・font-family は
+	 * 一切持たない（唯一の font-family 指定は html :where(.editor-styles-wrapper){...} と
+	 * 既にスコープされている）ことを確認済みで、この不具合は再発しない。
+	 *
+	 * 非 iframe のブロックエディター画面（widgets.php、カスタマイザー内のブロックウィジェット
+	 * 編集、旧来型メタボックスを持つプラグイン有効時に非 iframe へフォールバックした投稿編集画面
+	 * 等）では、WordPress コアが html セレクタを .editor-styles-wrapper へ書き換えるため、
+	 * rem の基準がフロントと異なる。rem 指定の見出し等（例: .h2,.mainSection-title,h2
+	 * { font-size: 1.75rem }）はフロントと違うサイズで表示される。widgets.php は
+	 * add_root_font_size_for_block_editor() で対処済み（詳細は同メソッドのコメントを参照）。
+	 * カスタマイザー内のブロックウィジェット編集と、非 iframe にフォールバックした投稿編集画面は
+	 * 対象外（未対応）で、この差は既知の制約として残っている。
+	 *
 	 * 旧実装にあった is_customize_preview() での早期リターンは、この方式には引き継いでいない。
 	 * 旧実装（enqueue_block_assets + wp_enqueue_style()）はカスタマイザー内で発火すると
 	 * 管理画面本体にも <link> が漏れるため、is_customize_preview() で個別に塞ぐ必要があった。
@@ -527,6 +543,11 @@ class Lightning_Design_Manager {
 	 * なる。get_parent_theme_file_path フィルターは /_g2 の付与に対応しているため、
 	 * サーバーパスの組み立てには get_template_directory() ではなく
 	 * get_parent_theme_file_path() を使う。
+	 *
+	 * この方式では CSS がブラウザキャッシュの効く <link> ではなく、編集画面ごとに
+	 * ブロックエディター設定へ埋め込まれる（bs4 系（origin2）で bootstrap.min.css 153,670
+	 * バイト＋ editor.css 5,453 バイトの合計約 159KB、gzip 前の実測値）。
+	 * エディター本文へ正しくスコープすることの構造的な対価として許容している。
 	 *
 	 * @param array                        $editor_settings      ブロックエディター設定.
 	 * @param WP_Block_Editor_Context|null $block_editor_context ブロックエディターのコンテキスト（未使用）.

--- a/_g2/inc/class-design-manager.php
+++ b/_g2/inc/class-design-manager.php
@@ -23,11 +23,16 @@ class Lightning_Design_Manager {
 
 		// Don't use following action point.
 		// wp : become do not load css.
+		// クラシックエディター（TinyMCE）向け。ブロックエディターにはタイミング上間に合わないため、
+		// ブロックエディター側は block_editor_settings_all（add_skin_css_to_block_editor_settings）で
+		// 別途対応している（詳細は同メソッドのコメントを参照）。
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_skin_editor_css' ), 11 );
 
 		add_action( 'customize_register', array( __CLASS__, 'customize_register' ) );
 
-		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_skin_gutenberg_css' ) );
+		add_filter( 'block_editor_settings_all', array( __CLASS__, 'add_skin_css_to_block_editor_settings' ), 10, 2 );
+
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'add_root_font_size_for_block_editor' ) );
 
 	}
 
@@ -39,27 +44,33 @@ class Lightning_Design_Manager {
 	public static function get_skins() {
 		$skins = array(
 			'origin'  => array(
-				'label'           => __( 'Origin ( Not recommended )', 'lightning' ),
-				'css_path'        => get_template_directory_uri() . '/design-skin/origin/css/style.css',
-				'css_sv_path'     => get_parent_theme_file_path( '/design-skin/origin/css/style.css' ),
-				'editor_css_path' => get_template_directory_uri() . '/design-skin/origin/css/editor.css',
+				'label'              => __( 'Origin ( Not recommended )', 'lightning' ),
+				'css_path'           => get_template_directory_uri() . '/design-skin/origin/css/style.css',
+				'css_sv_path'        => get_parent_theme_file_path( '/design-skin/origin/css/style.css' ),
+				'editor_css_path'    => get_template_directory_uri() . '/design-skin/origin/css/editor.css',
+				// add_skin_css_to_block_editor_settings() がサーバーパスを直接読めるように、
+				// editor_css_path に対応するサーバーパスを持たせる（URL 逆算・HTTP 取得を通らない）.
+				'editor_css_sv_path' => get_parent_theme_file_path( '/design-skin/origin/css/editor.css' ),
 				// 'gutenberg_css_path' => get_template_directory_uri() . '/design-skin/origin/css/editor-gutenberg.css',
-				'php_path'        => get_parent_theme_file_path( '/design-skin/origin/origin.php' ),
-				'js_path'         => '',
-				'callback'        => '',
-				'version'         => LIGHTNING_THEME_VERSION,
+				'php_path'           => get_parent_theme_file_path( '/design-skin/origin/origin.php' ),
+				'js_path'            => '',
+				'callback'           => '',
+				'version'            => LIGHTNING_THEME_VERSION,
 			),
 
 			'origin2' => array(
-				'label'           => __( 'Origin II ( Bootstrap4 )', 'lightning' ),
-				'css_path'        => get_template_directory_uri() . '/design-skin/origin2/css/style.css',
-				'css_sv_path'     => get_parent_theme_file_path( '/design-skin/origin2/css/style.css' ),
-				'css_late_path'   => '',
-				'editor_css_path' => get_template_directory_uri() . '/design-skin/origin2/css/editor.css',
-				'php_path'        => get_parent_theme_file_path( '/design-skin/origin2/origin2.php' ),
-				'js_path'         => '',
-				'version'         => LIGHTNING_THEME_VERSION,
-				'bootstrap'       => 'bs4',
+				'label'              => __( 'Origin II ( Bootstrap4 )', 'lightning' ),
+				'css_path'           => get_template_directory_uri() . '/design-skin/origin2/css/style.css',
+				'css_sv_path'        => get_parent_theme_file_path( '/design-skin/origin2/css/style.css' ),
+				'css_late_path'      => '',
+				'editor_css_path'    => get_template_directory_uri() . '/design-skin/origin2/css/editor.css',
+				// add_skin_css_to_block_editor_settings() がサーバーパスを直接読めるように、
+				// editor_css_path に対応するサーバーパスを持たせる（URL 逆算・HTTP 取得を通らない）.
+				'editor_css_sv_path' => get_parent_theme_file_path( '/design-skin/origin2/css/editor.css' ),
+				'php_path'           => get_parent_theme_file_path( '/design-skin/origin2/origin2.php' ),
+				'js_path'            => '',
+				'version'            => LIGHTNING_THEME_VERSION,
+				'bootstrap'          => 'bs4',
 			),
 		);
 		return apply_filters( 'lightning-design-skins', $skins ); // phpcs:ignore
@@ -217,6 +228,14 @@ class Lightning_Design_Manager {
 	/**
 	 * Load skin Editor CSS
 	 *
+	 * クラシックエディター（TinyMCE）が本文の見た目をフロントに合わせるために読み込む。
+	 * ブロックエディターの投稿・固定ページ編集画面／ウィジェット画面／サイトエディターは、
+	 * この関数が動く admin_enqueue_scripts（優先度 11）よりも前に編集画面の設定
+	 * （$editor_settings['styles']）を組み立て終えているため、add_editor_style() を
+	 * ここで呼んでもブロックエディターには一切反映されない。
+	 * ブロックエディター側は add_skin_css_to_block_editor_settings()
+	 * （block_editor_settings_all フィルター）で別途対応している。
+	 *
 	 * @return void
 	 */
 	public static function load_skin_editor_css() {
@@ -227,49 +246,406 @@ class Lightning_Design_Manager {
 	}
 
 	/**
-	 * Undocumented function
+	 * wp-content 配下の URL をサーバー上のファイルパスへ解決する
 	 *
-	 * @return void
+	 * スキンプラグインが返す editor CSS のパスは URL のため、*_sv_path（サーバーパス）を
+	 * 持たない旧スキンプラグインでも、ブロックエディター設定へ直接 CSS を埋め込む
+	 * （HTTP 取得を避ける）ために、まずサーバー上のパスへの逆算を試みる。
+	 * content_url() を WP_CONTENT_DIR に置き換えて候補パスを作り、realpath() で
+	 * 正規化したうえで WP_CONTENT_DIR 配下に収まっているか（.. によるパストラバーサルを
+	 * 含んでいないか）を確認してから返す。逆算できない・ファイルが存在しない・
+	 * WP_CONTENT_DIR 配下に収まらない場合は null を返し、呼び出し側で
+	 * get_remote_css_contents()（HTTP 取得）へのフォールバックに委ねる。
+	 *
+	 * @internal get_skin_editor_css_style_entry() からのみ呼び出す想定。
+	 *           任意のファイルを読み出す一次関数ではなく、外部からの直接呼び出しは想定していない。
+	 *
+	 * @param string $url CSS ファイルの URL.
+	 * @return string|null 解決できたサーバー上のパス。解決できない場合は null.
 	 */
-	public static function load_skin_gutenberg_css() {
-		// enqueue_block_assets はフロントでも動くため、ブロックエディタでのみ読み込む.
-		if ( ! is_admin() ) {
-			return;
+	private static function resolve_content_url_to_path( $url ) {
+		if ( ! is_string( $url ) || '' === $url ) {
+			return null;
 		}
 
-		// カスタマイズ画面でも読み込んでしまうので抹殺.
-		if ( is_customize_preview() ) {
-			return;
+		$content_url = untrailingslashit( content_url() );
+		if ( 0 !== strpos( $url, $content_url ) ) {
+			return null;
+		}
+
+		// クエリ文字列・フラグメントが付いている場合に備えて取り除く.
+		// strtok() はプロセス全体で内部状態を共有するため使わない（他所の strtok() 呼び出しを
+		// 壊す可能性がある）。
+		$relative_path = preg_replace( '/[?#].*$/', '', substr( $url, strlen( $content_url ) ) );
+
+		// URL はパーセントエンコードされていることがある（ディレクトリ名・ファイル名に
+		// 空白・非 ASCII 文字を含む構成等）。デコードしないと realpath() がファイルを
+		// 見つけられず、ローカル解決が黙って失敗して毎回 HTTP フォールバックへ落ちてしまう。
+		// デコードで .. のようなパストラバーサル文字列が復元される可能性があるため、
+		// 「デコード → 連結 → realpath() → 封じ込めチェック」の順序を必ず守る
+		// （デコードを後回しにしない）。
+		$relative_path = rawurldecode( $relative_path );
+
+		// %00 がデコードで NUL バイトへ変わることがある。PHP 8 の realpath() は
+		// NUL バイトを含むパスを渡すと ValueError を投げるため（PHP 7 は警告 + false）、
+		// wp_normalize_path() は NUL を除去しないので素通りしてしまう前提で、
+		// realpath() に渡す前にここで弾いておく.
+		if ( false !== strpos( $relative_path, "\0" ) ) {
+			return null;
+		}
+
+		$candidate_path = wp_normalize_path( WP_CONTENT_DIR . $relative_path );
+		$real_path      = realpath( $candidate_path );
+		if ( false === $real_path ) {
+			return null;
+		}
+		$real_path = wp_normalize_path( $real_path );
+
+		$real_content_dir = realpath( WP_CONTENT_DIR );
+		if ( false === $real_content_dir ) {
+			return null;
+		}
+		$real_content_dir = wp_normalize_path( $real_content_dir );
+
+		// WP_CONTENT_DIR 配下に収まっているかを確認する（.. によるパストラバーサル対策）。
+		// $url 自体が https://example.com/wp-content-evil/x.css のように content_url() を
+		// 文字列として含むだけの別ホストであっても、strpos() の時点では通ってしまうが、
+		// このチェックで正規化後のパスが WP_CONTENT_DIR 配下かどうかを見るため弾かれる。
+		$is_within_content_dir = ( $real_path === $real_content_dir )
+			|| ( 0 === strpos( $real_path, $real_content_dir . '/' ) );
+		if ( ! $is_within_content_dir ) {
+			return null;
+		}
+
+		if ( ! is_file( $real_path ) ) {
+			return null;
+		}
+
+		return $real_path;
+	}
+
+	/**
+	 * サーバー上の CSS ファイルの内容を読み込む
+	 *
+	 * @internal get_skin_editor_css_style_entry() および
+	 *           add_skin_css_to_block_editor_settings()（bootstrap.min.css 用）からのみ
+	 *           呼び出す想定。$path は is_file() 以外の制約を課さない任意パスの読み出しに
+	 *           なるため、外部からの直接呼び出しは想定していない。
+	 *
+	 * @param string $path サーバー上の CSS ファイルパス.
+	 * @return string|null 読み込めた内容。読み込めない場合は null.
+	 */
+	private static function get_local_css_contents( $path ) {
+		if ( ! is_string( $path ) || '' === $path || ! is_file( $path ) ) {
+			return null;
+		}
+
+		// get_block_editor_theme_styles()（WordPress コア）が同種の CSS を読み込む際も
+		// file_get_contents() を直接使っているため、それに合わせている.
+		$content = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $content ) {
+			return null;
+		}
+
+		return $content;
+	}
+
+	/**
+	 * CSS の URL を短いタイムアウトと transient キャッシュ付きで HTTP 取得する
+	 *
+	 * *_sv_path も content_url() からの逆算も使えない場合（新キーに未対応の
+	 * スキンプラグインが、content_url() 配下とは異なる URL 構造で CSS を配布している場合等）
+	 * の最終手段。wp_safe_remote_get() を使うため、内部 IP・非 HTTP スキームは弾かれるが、
+	 * 同一ホスト宛（自己参照）は例外的に許可されるため、正規のユースケース
+	 * （スキンプラグインが自サイト上の CSS を返す）は壊れない。
+	 *
+	 * 失敗・成功のいずれも、URL とスキンのバージョンから作ったキーで transient に
+	 * キャッシュする。ブロックエディターの画面を開くたびに毎回 HTTP 往復が発生するのを
+	 * 避けるため。成功時は 1 日、失敗時は 1 時間で再試行させる（失敗が長時間そのまま
+	 * 固定化しないように短くしている）。
+	 *
+	 * wp_safe_remote_get() が返す is_wp_error() は**トランスポート層の失敗のみ**
+	 * （DNS 不達・接続拒否・タイムアウト等）を表す。401（Basic 認証）・403・404・
+	 * 500・502 等は HTTP としては「成功」で返り、wp_remote_retrieve_body() は
+	 * エラーページの HTML 本文を返してしまう。これを CSS として扱うと、非 iframe 時に
+	 * コアの postcss 変換を通す際の挙動が読めないうえ、本来 1 時間で再試行させたい
+	 * 一時的な障害（502 等）まで 1 日キャッシュに固定化されてしまう。そのため
+	 * HTTP レスポンスコードが 200 以外の場合・ボディが空の場合は、どちらも
+	 * 失敗として扱い 1 時間キャッシュにする。
+	 *
+	 * 注意: キャッシュキーはスキンの version から作るため、version を返さない
+	 * スキンプラグイン（get_current_skin() は未設定なら空文字を補うため、この場合
+	 * キーは URL のみで決まる）では、CSS を更新してもキーが変わらず、最大 1 日は
+	 * 更新前の内容（または失敗キャッシュなら最大 1 時間）が使われ続ける可能性がある。
+	 * TTL に上限があるため実害は限定的。
+	 *
+	 * @internal get_skin_editor_css_style_entry() からのみ呼び出す想定。
+	 *
+	 * @param string $url     取得する CSS の URL.
+	 * @param string $version キャッシュキーに使うスキンのバージョン文字列.
+	 * @return string|null 取得できた CSS の内容。取得できなかった場合は null.
+	 */
+	private static function get_remote_css_contents( $url, $version ) {
+		$cache_key = 'ltg_ed_css_' . md5( $url . '|' . $version );
+
+		$cached = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return ( '' === $cached ) ? null : $cached;
+		}
+
+		$response = wp_safe_remote_get( $url, array( 'timeout' => 3 ) );
+		if ( is_wp_error( $response ) ) {
+			set_transient( $cache_key, '', HOUR_IN_SECONDS );
+			return null;
+		}
+
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			set_transient( $cache_key, '', HOUR_IN_SECONDS );
+			return null;
+		}
+
+		$css = wp_remote_retrieve_body( $response );
+		if ( '' === $css ) {
+			set_transient( $cache_key, '', HOUR_IN_SECONDS );
+			return null;
+		}
+
+		set_transient( $cache_key, $css, DAY_IN_SECONDS );
+
+		return $css;
+	}
+
+	/**
+	 * スキンの editor CSS からブロックエディター用の styles エントリを組み立てる
+	 *
+	 * 解決の優先順位は次のとおり（上ほど優先）。
+	 * 1. $sv_path（get_skins() の *_sv_path。get_parent_theme_file_path() で作った
+	 *    サーバーパス）があればそれをそのまま読む。テーマ同梱のスキン（Origin・Origin II）は
+	 *    常にここで解決し、URL 逆算・HTTP 取得を一切通らない。
+	 * 2. $sv_path が無い（新キーに未対応のスキンプラグイン等）場合は、$url を
+	 *    resolve_content_url_to_path() でサーバーパスへ逆算できないか試みる。
+	 * 3. それも駄目な場合だけ、get_remote_css_contents()（wp_safe_remote_get() +
+	 *    transient キャッシュ）で HTTP 取得する。
+	 *
+	 * add_editor_style() を呼ぶ形は採用していない。block_editor_settings_all フィルターの
+	 * 時点では、ブロックエディター設定の styles 配列が既に組み立て終わっており、
+	 * ここで add_editor_style() を呼んでも今回のリクエストのブロックエディターには
+	 * 一切反映されないため（クラシックエディター向けの load_skin_editor_css() と
+	 * 同じ URL を二重に登録するだけになる）。
+	 *
+	 * @internal add_skin_css_to_block_editor_settings() からのみ呼び出す想定。
+	 *
+	 * @param string $url     スキンが返す editor CSS の URL.
+	 * @param string $sv_path get_skins() が返す対応するサーバーパス（*_sv_path）。無ければ空文字.
+	 * @param string $version キャッシュキーに使うスキンのバージョン文字列.
+	 * @return array|null 追加すべき styles エントリ。取得できなかった場合は null.
+	 */
+	private static function get_skin_editor_css_style_entry( $url, $sv_path, $version ) {
+		$css = null;
+
+		if ( ! empty( $sv_path ) ) {
+			$css = self::get_local_css_contents( $sv_path );
+		}
+
+		if ( null === $css ) {
+			$resolved_path = self::resolve_content_url_to_path( $url );
+			if ( null !== $resolved_path ) {
+				$css = self::get_local_css_contents( $resolved_path );
+			}
+		}
+
+		if ( null === $css ) {
+			$css = self::get_remote_css_contents( $url, $version );
+		}
+
+		if ( null === $css ) {
+			return null;
+		}
+
+		return array(
+			'css'            => $css,
+			'baseURL'        => $url,
+			// __unstableType は WordPress コアの private API（wp-includes/block-editor.php の
+			// get_block_editor_theme_styles() 等が使う内部識別子）で、予告なく変更されうる。
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => false,
+		);
+	}
+
+	/**
+	 * スキンの CSS（Bootstrap ＋ スキンの editor CSS）をブロックエディター自身の styles へ追加する
+	 *
+	 * 従来は bootstrap.min.css・スキンの editor.css を enqueue_block_assets フックで
+	 * wp_enqueue_style() していたが（旧 load_skin_gutenberg_css()）、この方法は仕様上
+	 * ブロックエディターのプレビュー用 iframe だけでなく、管理画面のトップレベル文書
+	 * （wp-admin 本体）にも <link> として出力されてしまう。origin2（Bootstrap4）スキンの
+	 * editor.css には裸の body / html セレクタへの font-size・font-family 指定が含まれるため、
+	 * これが管理画面全体の基準文字サイズ・フォントを書き換えてしまい、サイドバー最下部の
+	 * 「メニューを閉じる」ボタンの文字が折り返される不具合の原因になっていた。
+	 *
+	 * block_editor_settings_all フィルターで $editor_settings['styles'] へ直接 CSS を
+	 * 追加する方式に切り替えた。この配列は WordPress コアの EditorStyles コンポーネントが
+	 * セレクタをエディター本文のスコープ（iframe 化されている場合は iframe 内の body、
+	 * されていない場合は .editor-styles-wrapper）へ書き換えたうえで描画するため、
+	 * この関数が追加する CSS は管理画面本体の <body class="wp-admin"> には構造的に
+	 * 到達しない。
+	 *
+	 * 旧実装にあった is_customize_preview() での早期リターンは、この方式には引き継いでいない。
+	 * 旧実装（enqueue_block_assets + wp_enqueue_style()）はカスタマイザー内で発火すると
+	 * 管理画面本体にも <link> が漏れるため、is_customize_preview() で個別に塞ぐ必要があった。
+	 * この方式は block_editor_settings_all の $editor_settings['styles'] へ追記するだけで、
+	 * どの文脈で呼ばれても管理画面本体には構造的に到達しないため、カスタマイザー内で
+	 * 発火したとしても新たな漏れは発生しない（is_admin() のチェックのみで足りる）。
+	 *
+	 * 追加順（bootstrap.min.css → スキンの editor_css_path → gutenberg_css_path）は、
+	 * 従来の load_skin_gutenberg_css() での enqueue 順を維持している。従来は
+	 * editor_css_path と gutenberg_css_path を同じハンドル（lightning-gutenberg-editor）で
+	 * enqueue していたため、両方設定されたスキンでは片方しか読まれなかったが、この実装では
+	 * 両方読み込む（両方指定したら両方読まれるのが素直な挙動であり、旧実装の取りこぼしを
+	 * 解消したもの。現行のスキン定義2本には両方設定したものは無いため、この変更による
+	 * 退行は無い）。
+	 *
+	 * bootstrap.min.css・editor_css_path は bs4 系スキン（'bootstrap' => 'bs4'）のときだけ
+	 * 追加する（従来の load_skin_gutenberg_css() と同じ条件）。一方 gutenberg_css_path は
+	 * bs4 かどうかに関係なく処理する。'bootstrap' キーを持たない bs3 系スキンプラグイン
+	 * （例: lightning-skin-charm・lightning-skin-fort の bs3 版）にも gutenberg_css_path を
+	 * 返すものが実在するため、bs4 判定の内側に入れると該当スキンでブロックエディターに
+	 * スキン CSS が一切読み込まれなくなる（旧実装から踏襲した分岐）。
+	 *
+	 * block_editor_settings_all はフロント側でブロックエディターを実装するプラグインからも
+	 * 発火し得るため、is_admin() で管理画面に限定する（従来の load_skin_gutenberg_css() の
+	 * 挙動を踏襲）。フロントにはスキンの style.css が wp_enqueue_scripts 側で別途
+	 * 読み込まれるため、ここでエディター用 CSS を追加で出す必要はない。
+	 *
+	 * bootstrap.min.css は _g2/library/bootstrap-4/css/bootstrap.min.css に同梱されている。
+	 * このテーマでは template_directory_uri フィルター（class-ltg-template-redirect.php）が
+	 * get_template_directory_uri() の戻り値に自動で /_g2 を付与するが、get_template_directory()
+	 * （URL ではなくファイルシステムパスを返す方）にはその補正が入らない（同ファイルの
+	 * template_directory フィルターは意図的にコメントアウトされている）。そのため
+	 * get_template_directory() . '/library/...' を直接組み立てると _g2 の無い誤ったパスに
+	 * なる。get_parent_theme_file_path フィルターは /_g2 の付与に対応しているため、
+	 * サーバーパスの組み立てには get_template_directory() ではなく
+	 * get_parent_theme_file_path() を使う。
+	 *
+	 * @param array                        $editor_settings      ブロックエディター設定.
+	 * @param WP_Block_Editor_Context|null $block_editor_context ブロックエディターのコンテキスト（未使用）.
+	 * @return array フィルター後のブロックエディター設定.
+	 */
+	public static function add_skin_css_to_block_editor_settings( $editor_settings, $block_editor_context = null ) {
+		if ( ! is_admin() ) {
+			return $editor_settings;
 		}
 
 		$skin_info = self::get_current_skin();
 
-		if ( isset( $skin_info['bootstrap'] ) && 'bs4' === $skin_info['bootstrap'] ) {
-			wp_enqueue_style(
-				'lightning-bootstrap-editor',
-				get_template_directory_uri() . '/library/bootstrap-4/css/bootstrap.min.css',
-				array( 'wp-edit-blocks' ),
-				$skin_info['version']
-			);
+		if ( ! isset( $editor_settings['styles'] ) || ! is_array( $editor_settings['styles'] ) ) {
+			$editor_settings['styles'] = array();
+		}
+
+		// bs4 系スキン（bootstrap.min.css を同梱で読み込むスキン）のときだけ、
+		// bootstrap.min.css とスキンの editor_css_path を追加する.
+		if ( ! empty( $skin_info['bootstrap'] ) && 'bs4' === $skin_info['bootstrap'] ) {
+			// bootstrap.min.css は自テーマ同梱のため、URL 逆算を介さずサーバーパスを直接組み立てる.
+			$bootstrap_path = get_parent_theme_file_path( '/library/bootstrap-4/css/bootstrap.min.css' );
+			$bootstrap_css  = self::get_local_css_contents( $bootstrap_path );
+			if ( null !== $bootstrap_css ) {
+				$editor_settings['styles'][] = array(
+					'css'            => $bootstrap_css,
+					'__unstableType' => 'theme',
+					'isGlobalStyles' => false,
+				);
+			}
+
 			if ( ! empty( $skin_info['editor_css_path'] ) ) {
-				wp_enqueue_style(
-					'lightning-gutenberg-editor',
+				$entry = self::get_skin_editor_css_style_entry(
 					$skin_info['editor_css_path'],
-					array( 'wp-edit-blocks' ),
+					isset( $skin_info['editor_css_sv_path'] ) ? $skin_info['editor_css_sv_path'] : '',
 					$skin_info['version']
 				);
+				if ( null !== $entry ) {
+					$editor_settings['styles'][] = $entry;
+				}
 			}
 		}
 
+		// gutenberg_css_path は bs4 かどうかに関係なく処理する（上記コメント参照）.
 		if ( ! empty( $skin_info['gutenberg_css_path'] ) ) {
-			wp_enqueue_style(
-				'lightning-gutenberg-editor',
+			$entry = self::get_skin_editor_css_style_entry(
 				$skin_info['gutenberg_css_path'],
-				array( 'wp-edit-blocks' ),
+				isset( $skin_info['gutenberg_css_sv_path'] ) ? $skin_info['gutenberg_css_sv_path'] : '',
 				$skin_info['version']
 			);
+			if ( null !== $entry ) {
+				$editor_settings['styles'][] = $entry;
+			}
 		}
 
+		return $editor_settings;
+	}
+
+	/**
+	 * ブロックエディターのルート文字サイズの基準をフロントと揃える（ウィジェット画面限定）
+	 *
+	 * block_editor_settings_all で渡す $editor_settings['styles'] は、WordPress コアが
+	 * セレクタをエディター本文のスコープへ書き換えてから描画する。ブロックエディターの
+	 * プレビュー用 iframe（投稿・固定ページ編集画面、サイトエディター）では iframe 自身の
+	 * 実の html 要素にそのまま届くため、テーマの html { font-size: ... } はフロントと
+	 * 同じ基準で効く。一方、iframe 化されていないウィジェット画面（widgets.php）では、
+	 * コアが html セレクタを .editor-styles-wrapper 自身へ書き換えてしまう。rem は常に
+	 * 「本当の」ルート要素（このケースでは管理画面本体の実の html 要素）の font-size を
+	 * 基準に計算されるため、.editor-styles-wrapper だけに font-size を与えても rem 指定の
+	 * 見出し等（例: .h2,.mainSection-title,h2 { font-size: 1.75rem }）はフロントと異なる
+	 * サイズで表示されてしまう。
+	 *
+	 * この対処は widgets.php（$pagenow で判定）に限定して、管理画面本体の実の html 要素に
+	 * のみ font-size を与える。html セレクタのみに絞っており、body の font-size・font-family
+	 * までは含めない。
+	 *
+	 * origin2 スキンの editor.css は 992px 以下で body,html{font-size:14px}、992px 超で
+	 * body,html{font-size:16px} を指定している。この関数は同じブレークポイント・比率を
+	 * 管理画面本体の実の html 要素にも与える（87.5% = 14px、100% = 16px、いずれも
+	 * ブラウザの既定文字サイズ 16px からの相対値）。
+	 *
+	 * トレードオフ: この出力により、幅 992px 以下の widgets.php では管理画面本体の rem 基準が
+	 * 16px から 14px に変わり、wp-admin/css/forms.css の input[type=checkbox] /
+	 * input[type=radio]（1rem 前提）が約 2px（12.5%）縮小する。これは意図した代償である。
+	 * 出力しない場合、ウィジェット画面のブロックプレビューで rem 指定の見出しがフロントより
+	 * 大きく表示され続けるため、編集対象ではない管理 UI が 2px 縮むことより、編集中の本文の
+	 * 見た目がフロントとずれ続けることの方が実害が大きいと判断し、こちらを選んでいる。
+	 *
+	 * @return void
+	 */
+	public static function add_root_font_size_for_block_editor() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		global $pagenow;
+		if ( 'widgets.php' !== $pagenow ) {
+			return;
+		}
+
+		$skin_info = self::get_current_skin();
+		if ( empty( $skin_info['bootstrap'] ) || 'bs4' !== $skin_info['bootstrap'] ) {
+			return;
+		}
+
+		// design-skin/foundation/_scss/_variables.scss の $md-max（現在 992px）に合わせている。
+		// ビルド済み CSS が出力するレンジ構文 @media (992px < width) と表記を揃えている
+		// （min-width の等号境界での食い違いを避けるため）。$md-max を変更した場合は
+		// この値も追随させること（自動連携の手段は無いため、変更時に手動で揃える）。
+		//
+		// テーマの SCSS 側は px 表記だが、ここだけ意図的に相対単位（%）にしている。px 固定だと、
+		// 読みやすさのためにブラウザの既定文字サイズを（16px より）大きく設定している利用者の
+		// 設定を無条件に握りつぶし、rem 基準の管理 UI がその人にとって縮んで見えてしまう。
+		// % はブラウザの既定文字サイズからの相対値のため、既定（16px）の利用者への挙動は
+		// px 指定と完全に同じ（87.5% = 14px、100% = 既定値そのもの）ままで、既定より大きく
+		// 設定している利用者の設定だけを尊重できる。
+		wp_add_inline_style(
+			'wp-edit-blocks',
+			'html{font-size:87.5%}@media (992px < width){html{font-size:100%}}'
+		);
 	}
 
 	/**

--- a/_g2/tests/test-lightning-design-manager-block-editor-styles.php
+++ b/_g2/tests/test-lightning-design-manager-block-editor-styles.php
@@ -1,0 +1,749 @@
+<?php
+/**
+ * Class LightningDesignManagerBlockEditorStylesTest
+ *
+ * @package Lightning
+ */
+
+/**
+ * Lightning_Design_Manager::add_skin_css_to_block_editor_settings()（block_editor_settings_all
+ * フィルター経由でブロックエディターへ CSS を渡す処理）を検証するテスト。
+ *
+ * これまで bootstrap.min.css・スキンの editor.css を enqueue_block_assets フックで
+ * wp_enqueue_style() していたが（旧 load_skin_gutenberg_css()）、この方法はブロックエディターの
+ * プレビュー用 iframe だけでなく、管理画面のトップレベル文書（wp-admin 本体）にも <link> として
+ * 出力されてしまい、origin2 スキンの editor.css が持つ裸の body / html セレクタへの
+ * font-size・font-family 指定が管理画面全体に漏れ、サイドバー最下部の「メニューを閉じる」
+ * ボタンの文字が折り返される不具合が起きていた。
+ *
+ * この不具合を根治するため、block_editor_settings_all フィルターで
+ * $editor_settings['styles'] へ直接 CSS を追加する方式に切り替えた。
+ *
+ * resolve_content_url_to_path() / get_local_css_contents() / get_skin_editor_css_style_entry()
+ * は private のため、このテストは公開されている add_skin_css_to_block_editor_settings()
+ * （block_editor_settings_all フィルターの実体）を経由してのみ検証する。
+ */
+class LightningDesignManagerBlockEditorStylesTest extends WP_UnitTestCase {
+
+	/**
+	 * テスト用に作成した一時ファイル・ディレクトリのパス一覧。tear_down() で削除する。
+	 *
+	 * @var array
+	 */
+	private $temp_paths = array();
+
+	/**
+	 * lightning-design-skins フィルターに追加したコールバック一覧。tear_down() で必ず外す
+	 * （テスト内のアサーションで失敗した場合でも filter が残らないようにするため）。
+	 *
+	 * @var array
+	 */
+	private $skins_filters = array();
+
+	/**
+	 * pre_http_request フィルターに追加したコールバック一覧。tear_down() で必ず外す。
+	 *
+	 * @var array
+	 */
+	private $http_filters = array();
+
+	/**
+	 * set_up() 時点の $pagenow（グローバル）。tear_down() で元に戻す。
+	 *
+	 * @var string|null
+	 */
+	private $original_pagenow;
+
+	/**
+	 * 各テストの前に、管理画面のブロックエディター画面にいる状態を模す
+	 * （add_skin_css_to_block_editor_settings() は is_admin() を見るため）。
+	 */
+	public function set_up() {
+		parent::set_up();
+		set_current_screen( 'edit-post' );
+
+		global $pagenow;
+		$this->original_pagenow = $pagenow;
+	}
+
+	/**
+	 * テスト後に一時ファイル・ディレクトリ・オプション・フィルター・$pagenow を片付ける。
+	 */
+	public function tear_down() {
+		foreach ( $this->skins_filters as $filter ) {
+			remove_filter( 'lightning-design-skins', $filter );
+		}
+		foreach ( $this->http_filters as $filter ) {
+			remove_filter( 'pre_http_request', $filter );
+		}
+		foreach ( array_reverse( $this->temp_paths ) as $path ) {
+			if ( is_file( $path ) ) {
+				wp_delete_file( $path );
+			} elseif ( is_dir( $path ) ) {
+				rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			}
+		}
+		delete_option( 'lightning_design_skin' );
+
+		global $pagenow;
+		$pagenow = $this->original_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		set_current_screen( 'front' );
+		parent::tear_down();
+	}
+
+	/**
+	 * pre_http_request をブロックし、HTTP 取得（wp_safe_remote_get() 経由）が
+	 * 発生した場合は常に WP_Error を返すようにする。パストラバーサル等、ローカル解決が
+	 * 失敗するはずのテストで、実際のネットワークアクセスが起きないようにするため。
+	 */
+	private function block_remote_requests() {
+		$filter = static function () {
+			return new WP_Error( 'blocked_in_test', 'blocked in test' );
+		};
+		add_filter( 'pre_http_request', $filter );
+		$this->http_filters[] = $filter;
+	}
+
+	/**
+	 * pre_http_request をモックし、指定した本文・HTTP レスポンスコードで常に応答する
+	 * ようにする。実際のネットワークアクセスは発生しない。呼び出し回数を数えられる
+	 * ように、カウンタを持つ stdClass を返す（transient キャッシュが効いて2回目以降は
+	 * 呼ばれないことを検証するため）。
+	 *
+	 * @param string $body 応答するボディ.
+	 * @param int    $code 応答する HTTP レスポンスコード.
+	 * @return stdClass ->count に呼び出し回数が入るオブジェクト.
+	 */
+	private function mock_remote_response( $body, $code ) {
+		$tracker        = new stdClass();
+		$tracker->count = 0;
+
+		$filter = function () use ( $body, $code, $tracker ) {
+			++$tracker->count;
+			return array(
+				'headers'  => array(),
+				'body'     => $body,
+				'response' => array(
+					'code'    => $code,
+					'message' => '',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+		$this->http_filters[] = $filter;
+
+		return $tracker;
+	}
+
+	/**
+	 * $editor_settings['styles'] から、__unstableType が 'theme' のエントリだけを
+	 * 抜き出す（スキン CSS 以外の既定エントリと混ざらないようにするため）。
+	 *
+	 * @param array $editor_settings add_skin_css_to_block_editor_settings() の戻り値.
+	 * @return array 'theme' エントリだけの配列（連番に振り直し済み）.
+	 */
+	private function get_theme_style_entries( $editor_settings ) {
+		return array_values(
+			array_filter(
+				$editor_settings['styles'],
+				static function ( $entry ) {
+					return isset( $entry['__unstableType'] ) && 'theme' === $entry['__unstableType'];
+				}
+			)
+		);
+	}
+
+	/**
+	 * add_skin_css_to_block_editor_settings() が、is_admin() が偽（フロント表示）の
+	 * 場合には何もせず $editor_settings をそのまま返すことを検証する（block_editor_settings_all
+	 * はフロント側でブロックエディターを実装するプラグインからも発火し得るため、
+	 * 管理画面に限定している）。
+	 *
+	 * 条件が1つ（is_admin() が偽）しかなく、表にする意味が薄いため単一シナリオのままにしている。
+	 */
+	public function test_add_skin_css_to_block_editor_settings_returns_unchanged_outside_admin() {
+		set_current_screen( 'front' );
+		update_option( 'lightning_design_skin', 'origin2' );
+
+		$original        = array( 'styles' => array( array( 'css' => 'existing' ) ) );
+		$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( $original, null );
+
+		$this->assertSame(
+			$original,
+			$editor_settings,
+			'is_admin() が偽の場合は $editor_settings を変更せずそのまま返す必要があります。'
+		);
+	}
+
+	/**
+	 * add_skin_css_to_block_editor_settings() が、bs4 系スキン（Origin II）が有効な場合に
+	 * bootstrap.min.css → スキンの editor.css の順で $editor_settings['styles'] へ
+	 * 追加することを検証する。Origin II は editor_css_sv_path を持つため、この経路は
+	 * サーバーパスを直接読む（URL 逆算・HTTP 取得を通らない）。
+	 *
+	 * 「2件が、この順序で入っている」という単一の並び順の検証であり、条件の組み合わせ表には
+	 * ならないため単一シナリオのままにしている。
+	 *
+	 * この関数はコアから渡された $editor_settings['styles']（グローバルスタイル・
+	 * テーマスタイル等、既存のエントリ）へ「追記」する位置にいる。将来 誤って
+	 * `$editor_settings['styles'] = array(...)` のような代入に書き換えられると、
+	 * 既存のエントリが丸ごと消えてしまう（エディターのスタイルが全滅する）。
+	 * それを検出するため、入力に既存エントリを含め、加工後も残っていることを検証する。
+	 */
+	public function test_add_skin_css_to_block_editor_settings_adds_bootstrap_and_skin_css_in_order() {
+		update_option( 'lightning_design_skin', 'origin2' );
+
+		$original        = array( 'styles' => array( array( 'css' => 'existing' ) ) );
+		$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( $original, null );
+
+		$this->assertArrayHasKey( 'styles', $editor_settings );
+
+		// 既存の styles エントリ（コアのグローバルスタイル・テーマスタイル等を模したもの）が、
+		// 追記後も落ちずに残っていることを確認する（追記ではなく代入に書き換えられる事故の検出）.
+		$this->assertContains(
+			array( 'css' => 'existing' ),
+			$editor_settings['styles'],
+			'既存の styles エントリが、スキン CSS の追記後も残っている必要があります。'
+		);
+
+		$theme_entries = $this->get_theme_style_entries( $editor_settings );
+
+		// bs4 系スキンでは bootstrap.min.css とスキンの editor.css の2件が追加される想定.
+		$this->assertCount(
+			2,
+			$theme_entries,
+			'bs4 系スキンでは bootstrap.min.css とスキンの editor.css の2件が styles に追加される必要があります。'
+		);
+
+		// 1件目（bootstrap.min.css）は baseURL を持たない（自テーマのサーバーパスを直接読むため）。
+		// Bootstrap 固有のクラス（.btn-primary。editor.css には含まれない）で判定する。
+		$this->assertArrayNotHasKey(
+			'baseURL',
+			$theme_entries[0],
+			'1件目（bootstrap.min.css）は baseURL を持たない想定です。'
+		);
+		$this->assertStringContainsString(
+			'.btn-primary',
+			$theme_entries[0]['css'],
+			'1件目は bootstrap.min.css の内容（Bootstrap 固有の .btn-primary を含む）である必要があります。'
+		);
+
+		// 2件目（スキンの editor.css）は baseURL を持ち、origin2/css/editor.css を指す.
+		$this->assertArrayHasKey(
+			'baseURL',
+			$theme_entries[1],
+			'2件目（スキンの editor.css）は baseURL を持つ必要があります。'
+		);
+		$this->assertStringContainsString(
+			'design-skin/origin2/css/editor.css',
+			$theme_entries[1]['baseURL'],
+			'2件目は origin2 スキンの editor.css を指す必要があります。'
+		);
+	}
+
+	/**
+	 * add_skin_css_to_block_editor_settings() の bs4 判定分岐を検証する。
+	 *
+	 * 「bs4 判定の内側に gutenberg_css_path の処理を入れてしまい、bs3 系スキンプラグインで
+	 * ブロックエディターにスキン CSS が一切読み込まれなくなる」という退行の再発防止を兼ねる。
+	 * lightning-skin-charm・lightning-skin-fort の bs3 版など、'bootstrap' キーを持たずに
+	 * gutenberg_css_path だけを返すスキンプラグインが実在するため、'lightning-design-skins'
+	 * フィルターでそれを模して検証する。
+	 */
+	public function test_add_skin_css_to_block_editor_settings_bs4_branching() {
+		$dir = WP_CONTENT_DIR . '/lightning-test-' . wp_generate_password( 8, false );
+		mkdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$this->temp_paths[] = $dir;
+
+		$file = $dir . '/editor-gutenberg.css';
+		file_put_contents( $file, 'body{color:green}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		$this->temp_paths[] = $file;
+
+		$url = content_url( '/' . basename( $dir ) . '/editor-gutenberg.css' );
+
+		$filter = static function ( $skins ) use ( $url ) {
+			// 'bootstrap' キーも '*_sv_path' も意図的に持たせない
+			// （新キーに未対応の bs3 系スキンプラグインを模している）.
+			$skins['bs3-plugin-skin']          = array(
+				'label'              => 'BS3 Plugin Skin (test)',
+				'gutenberg_css_path' => $url,
+			);
+			// 'bootstrap' キーに 'bs4' 以外の値を明示的に持たせたケース
+			// （キー自体が無いケースとは別に、「bs4 ではない値が入っている」場合の
+			// 境界も確認するため）.
+			$skins['bs3-explicit-plugin-skin'] = array(
+				'label'              => 'BS3 Explicit Plugin Skin (test)',
+				'bootstrap'          => 'bs3',
+				'gutenberg_css_path' => $url,
+			);
+			return $skins;
+		};
+		add_filter( 'lightning-design-skins', $filter );
+		$this->skins_filters[] = $filter;
+
+		$test_cases = array(
+			array(
+				'test_condition_name'   => 'bootstrap キーも gutenberg_css_path も持たない bs3 系スキン（Origin）の場合 => 何も追加されない',
+				'skin_key'              => 'origin',
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+			array(
+				'test_condition_name'   => 'bootstrap キーを持たないが gutenberg_css_path だけを持つ bs3 系スキンプラグインの場合 => 1件追加される',
+				'skin_key'              => 'bs3-plugin-skin',
+				'expected_count'        => 1,
+				'expected_css_contains' => 'color:green',
+			),
+			array(
+				'test_condition_name'   => 'bootstrap キーに bs4 以外の値（bs3）を明示的に持つスキンプラグインの場合 => gutenberg_css_path だけが1件追加される',
+				'skin_key'              => 'bs3-explicit-plugin-skin',
+				'expected_count'        => 1,
+				'expected_css_contains' => 'color:green',
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option( 'lightning_design_skin', $case['skin_key'] );
+
+			$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+			$theme_entries   = $this->get_theme_style_entries( $editor_settings );
+
+			$this->assertCount( $case['expected_count'], $theme_entries, $case['test_condition_name'] );
+
+			if ( null !== $case['expected_css_contains'] ) {
+				$this->assertStringContainsString( $case['expected_css_contains'], $theme_entries[0]['css'], $case['test_condition_name'] );
+			}
+
+			delete_option( 'lightning_design_skin' );
+		}
+	}
+
+	/**
+	 * gutenberg_css_path の URL 解決（resolve_content_url_to_path()）を、
+	 * add_skin_css_to_block_editor_settings() 経由で検証する。
+	 *
+	 * - パーセントエンコードされた URL（空白・非 ASCII 文字を含むパス）が正しく
+	 *   ローカル解決されること（rawurldecode() 追加分の回帰テスト）
+	 * - '../' によるパストラバーサル（非エンコード・パーセントエンコードの両方）が、
+	 *   デコード後の realpath() 正規化 + WP_CONTENT_DIR 配下チェックで拒否されること
+	 * - content_url() を文字列として「含むだけ」の別ホスト URL（前方一致だけでは
+	 *   弾けないケース）が、後続の配下チェックで拒否されること
+	 * - %00（NUL バイト）を含む URL が、致命的エラー（PHP 8 の realpath() が NUL バイトを
+	 *   含むパスに対して投げる ValueError）にならず、null として扱われること
+	 *
+	 * ローカル解決に失敗するケースはすべて HTTP 取得（wp_safe_remote_get()）へ進むため、
+	 * ループの外側で一括して pre_http_request をブロックし、実際のネットワークアクセスが
+	 * 起きないようにする。
+	 */
+	public function test_add_skin_css_to_block_editor_settings_gutenberg_css_path_url_resolution() {
+		$this->block_remote_requests();
+
+		// ケース1: 半角スペースを含むディレクトリ名（パーセントエンコードされた URL）.
+		$dir_with_space = WP_CONTENT_DIR . '/lightning test ' . wp_generate_password( 6, false );
+		mkdir( $dir_with_space ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$this->temp_paths[] = $dir_with_space;
+		$file_with_space     = $dir_with_space . '/editor-gutenberg.css';
+		file_put_contents( $file_with_space, '.ltg-space-marker{color:blue}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		$this->temp_paths[] = $file_with_space;
+		$url_with_space      = content_url( '/' . rawurlencode( basename( $dir_with_space ) ) . '/editor-gutenberg.css' );
+
+		// ケース2: 日本語のファイル名（パーセントエンコードされた URL）.
+		$dir_ja = WP_CONTENT_DIR . '/lightning-test-' . wp_generate_password( 8, false );
+		mkdir( $dir_ja ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$this->temp_paths[] = $dir_ja;
+		$file_ja = $dir_ja . '/エディタ.css';
+		file_put_contents( $file_ja, '.ltg-ja-marker{color:orange}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		$this->temp_paths[] = $file_ja;
+		$url_ja  = content_url( '/' . basename( $dir_ja ) . '/' . rawurlencode( 'エディタ.css' ) );
+
+		// ケース3: '../' によるパストラバーサル（非エンコード）。WP_CONTENT_DIR から見て
+		// ABSPATH . 'wp-load.php'（標準構成で確実に存在する）を狙う。
+		// content_url( '/../wp-config.php' ) を使わない理由: wp-config.php を
+		// WP_CONTENT_DIR のひとつ上の階層に置く構成（公式サポート）では、そもそも
+		// realpath() の時点で false になり、配下チェックへ到達せずに null になる。
+		// それでは「封じ込めチェックが効いた」のか「ファイルが無かっただけ」かを
+		// 区別できないため、確実に存在するファイルを狙わせる.
+		$traversal_url = content_url( '/../wp-load.php' );
+
+		// ケース4: パーセントエンコードされたパストラバーサル（%2e%2e%2f = '../'）。
+		// デコードを追加したことで、%2e%2e%2f のようなエンコード済みトラバーサルが
+		// 実在するパスへ復元されるようになった（デコード前は 1 セグメントのファイル名として
+		// 扱われ realpath() が false を返していた）。デコードを配下チェックより後ろに
+		// 移すと素通りするため、この順序を固定する.
+		$encoded_traversal_url = content_url() . '/%2e%2e%2fwp-load.php';
+
+		// ケース6: %00（NUL バイト）を含む URL。デコードにより NUL バイトへ変わり、
+		// PHP 8 の realpath() はこれを渡すと ValueError を投げる。致命的エラーにならず
+		// null を返す（=styles に何も追加されない）ことを確認する.
+		$null_byte_url = content_url( '/editor%00.css' );
+
+		// ケース5: content_url() を文字列として「含むだけ」の別ホスト URL
+		// （例: https://example.com/wp-content-evil/x.css）。strpos() による前方一致
+		// チェックだけでは弾けないが、その後の候補パスが実在しないディレクトリを指すため
+		// realpath() が false を返して弾かれる想定.
+		$boundary_url = untrailingslashit( content_url() ) . '-evil/x.css';
+
+		$filter = static function ( $skins ) use ( $url_with_space, $url_ja, $traversal_url, $encoded_traversal_url, $boundary_url, $null_byte_url ) {
+			$skins['url-res-space']             = array(
+				'label'              => 'URL Resolution Space (test)',
+				'gutenberg_css_path' => $url_with_space,
+			);
+			$skins['url-res-ja']                = array(
+				'label'              => 'URL Resolution JA (test)',
+				'gutenberg_css_path' => $url_ja,
+			);
+			$skins['url-res-traversal']         = array(
+				'label'              => 'URL Resolution Traversal (test)',
+				'gutenberg_css_path' => $traversal_url,
+			);
+			$skins['url-res-encoded-traversal'] = array(
+				'label'              => 'URL Resolution Encoded Traversal (test)',
+				'gutenberg_css_path' => $encoded_traversal_url,
+			);
+			$skins['url-res-boundary']          = array(
+				'label'              => 'URL Resolution Boundary (test)',
+				'gutenberg_css_path' => $boundary_url,
+			);
+			$skins['url-res-null-byte']         = array(
+				'label'              => 'URL Resolution Null Byte (test)',
+				'gutenberg_css_path' => $null_byte_url,
+			);
+			return $skins;
+		};
+		add_filter( 'lightning-design-skins', $filter );
+		$this->skins_filters[] = $filter;
+
+		$test_cases = array(
+			array(
+				'test_condition_name'   => '半角スペースを含むディレクトリ名がパーセントエンコードされた URL の場合 => ローカル解決されて1件追加される',
+				'skin_key'              => 'url-res-space',
+				'expected_count'        => 1,
+				'expected_css_contains' => '.ltg-space-marker',
+			),
+			array(
+				'test_condition_name'   => '日本語のファイル名がパーセントエンコードされた URL の場合 => ローカル解決されて1件追加される',
+				'skin_key'              => 'url-res-ja',
+				'expected_count'        => 1,
+				'expected_css_contains' => '.ltg-ja-marker',
+			),
+			array(
+				'test_condition_name'   => '非エンコードの \'../\' によるパストラバーサルの場合 => 封じ込めチェックで拒否され0件',
+				'skin_key'              => 'url-res-traversal',
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+			array(
+				'test_condition_name'   => 'パーセントエンコードされたパストラバーサル（%2e%2e%2f）の場合 => デコード後の封じ込めチェックで拒否され0件',
+				'skin_key'              => 'url-res-encoded-traversal',
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+			array(
+				'test_condition_name'   => 'content_url() を文字列として含むだけの別ホスト URL の場合 => 封じ込めチェックで拒否され0件',
+				'skin_key'              => 'url-res-boundary',
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+			array(
+				'test_condition_name'   => '%00（NUL バイト）を含む URL の場合 => 致命的エラーにならず null が返り0件',
+				'skin_key'              => 'url-res-null-byte',
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			update_option( 'lightning_design_skin', $case['skin_key'] );
+
+			$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+			$theme_entries   = $this->get_theme_style_entries( $editor_settings );
+
+			$this->assertCount( $case['expected_count'], $theme_entries, $case['test_condition_name'] );
+
+			if ( null !== $case['expected_css_contains'] ) {
+				$this->assertStringContainsString( $case['expected_css_contains'], $theme_entries[0]['css'], $case['test_condition_name'] );
+			}
+
+			delete_option( 'lightning_design_skin' );
+		}
+	}
+
+	/**
+	 * 管理画面本体に <link> が出力される不具合そのものの回帰テスト。
+	 *
+	 * 将来誰かが「エディターにスタイルが足りない」という理由で、
+	 * enqueue_block_assets フックへ wp_enqueue_style( 'lightning-gutenberg-editor', ... )
+	 * や wp_enqueue_style( 'lightning-bootstrap-editor', ... ) を復活させた場合に、
+	 * このテストが失敗して検出できるようにする。
+	 *
+	 * 「特定のハンドルが enqueue されていないこと」を確認するだけの単一の回帰チェックで
+	 * あり、条件の組み合わせ表にはならないため単一シナリオのままにしている。
+	 */
+	public function test_enqueue_block_assets_does_not_enqueue_legacy_editor_styles() {
+		update_option( 'lightning_design_skin', 'origin2' );
+
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertFalse(
+			wp_style_is( 'lightning-gutenberg-editor', 'enqueued' ),
+			'enqueue_block_assets で lightning-gutenberg-editor が enqueue されてはいけません（管理画面本体への漏れの再発）。'
+		);
+		$this->assertFalse(
+			wp_style_is( 'lightning-bootstrap-editor', 'enqueued' ),
+			'enqueue_block_assets で lightning-bootstrap-editor が enqueue されてはいけません（管理画面本体への漏れの再発）。'
+		);
+	}
+
+	/**
+	 * add_root_font_size_for_block_editor() が、$pagenow が widgets.php のときだけ
+	 * html の font-size を出力し、post.php・site-editor.php では出力しないことを検証する。
+	 *
+	 * この対処はウィジェット画面（非 iframe）限定で rem 基準のずれを補うためのもので、
+	 * 投稿編集画面・サイトエディター（iframe 化されており対処不要）にまで広げてしまうと、
+	 * 管理画面本体へ不要に CSS を出力することになる。
+	 *
+	 * wp_add_inline_style() は一度追加した内容を取り消さない（累積する）ため、
+	 * 各ケースの実行順序に意味がある。widgets.php のケースを先に実行してしまうと、
+	 * 後続の post.php・site-editor.php のケースで「まだ出力されていないこと」を
+	 * 検証できなくなる。そのため配列の並び順（post.php → site-editor.php →
+	 * widgets.php）を変更してはいけない。
+	 */
+	public function test_add_root_font_size_for_block_editor_only_applies_on_widgets_screen() {
+		update_option( 'lightning_design_skin', 'origin2' );
+
+		$expected_css = 'html{font-size:87.5%}@media (992px < width){html{font-size:100%}}';
+
+		global $pagenow;
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'pagenow が post.php（投稿編集画面、iframe 化されている）の場合 => 出力されない',
+				'pagenow'             => 'post.php',
+				'expected_contains'   => false,
+			),
+			array(
+				'test_condition_name' => 'pagenow が site-editor.php（iframe 化されている）の場合 => 出力されない',
+				'pagenow'             => 'site-editor.php',
+				'expected_contains'   => false,
+			),
+			array(
+				'test_condition_name' => 'pagenow が widgets.php（非 iframe）の場合 => 出力される',
+				'pagenow'             => 'widgets.php',
+				'expected_contains'   => true,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$pagenow = $case['pagenow']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			do_action( 'enqueue_block_assets' );
+
+			$inline_styles = (array) wp_styles()->get_data( 'wp-edit-blocks', 'after' );
+
+			if ( $case['expected_contains'] ) {
+				$this->assertContains( $expected_css, $inline_styles, $case['test_condition_name'] );
+			} else {
+				$this->assertNotContains( $expected_css, $inline_styles, $case['test_condition_name'] );
+			}
+		}
+	}
+
+	/**
+	 * *_sv_path（get_skins() のサーバーパス）が、URL からの逆算・HTTP 取得より
+	 * 優先されることを固定するテスト。
+	 *
+	 * gutenberg_css_path には URL 逆算（resolve_content_url_to_path()）でも
+	 * HTTP 取得（get_remote_css_contents()。pre_http_request をブロックしているため
+	 * 必ず失敗する）でも解決できない URL を与え、gutenberg_css_sv_path にだけ
+	 * 一意のマーカーを含むファイルを指定する。styles にマーカー入りの内容が
+	 * 追加されれば、*_sv_path 経由で解決されたことが確定する（URL 逆算や HTTP に
+	 * フォールバックしていれば、内容が一致しないか、そもそも styles に何も
+	 * 追加されない）。
+	 *
+	 * WP のテスト環境では content_url() と WP_CONTENT_DIR が対応しているため、
+	 * gutenberg_css_path 自体を wp-content 配下の URL にしてしまうと、*_sv_path の
+	 * 参照が壊れていても URL 逆算が同じ結果を返してこのテストの意図が守れない。
+	 * そのため gutenberg_css_path は wp-content の外（example.com）を指す URL にする。
+	 *
+	 * 「到達不可能な URL」と「一意なマーカーを持つ sv_path」を組み合わせた単一シナリオで
+	 * 優先順位を確定させるものであり、条件の組み合わせ表にはならないため単一シナリオの
+	 * ままにしている。
+	 */
+	public function test_sv_path_takes_priority_over_url_resolution_and_http() {
+		$this->block_remote_requests();
+
+		$dir = WP_CONTENT_DIR . '/lightning-test-' . wp_generate_password( 8, false );
+		mkdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$this->temp_paths[] = $dir;
+
+		$file = $dir . '/editor-gutenberg.css';
+		file_put_contents( $file, '.ltg-sv-path-marker{color:red}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		$this->temp_paths[] = $file;
+
+		$filter = static function ( $skins ) use ( $file ) {
+			$skins['sv-skin'] = array(
+				'label'                 => 'SV Skin (test)',
+				// wp-content の外（example.com）を指すため、URL 逆算では解決できず、
+				// HTTP はブロックされているため必ず失敗する.
+				'gutenberg_css_path'    => 'https://example.com/nowhere/unreachable.css',
+				'gutenberg_css_sv_path' => $file,
+			);
+			return $skins;
+		};
+		add_filter( 'lightning-design-skins', $filter );
+		$this->skins_filters[] = $filter;
+
+		update_option( 'lightning_design_skin', 'sv-skin' );
+
+		$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+		$theme_entries   = $this->get_theme_style_entries( $editor_settings );
+
+		$this->assertCount(
+			1,
+			$theme_entries,
+			'gutenberg_css_sv_path 経由で解決できるはずのスキンで、styles に何も追加されていません（sv_path が使われていない可能性があります）。'
+		);
+		$this->assertStringContainsString(
+			'.ltg-sv-path-marker',
+			$theme_entries[0]['css'],
+			'*_sv_path 経由で解決された内容（マーカー入り）である必要があります。URL 逆算や HTTP にフォールバックしていないことを確認してください。'
+		);
+	}
+
+	/**
+	 * get_remote_css_contents() の HTTP レスポンス処理（200 応答時の取得成功、
+	 * 200 以外は本文の内容にかかわらず失敗として扱うこと）を検証する。
+	 *
+	 * transient キャッシュにより2回目の呼び出しでは実際の HTTP リクエストが
+	 * 発生しないことの検証は、1回目・2回目の呼び出し順序そのものに意味があるため、
+	 * このテストには含めず test_http_fallback_succeeds_and_caches_via_transient() に
+	 * 単一シナリオとして残している。
+	 */
+	public function test_get_skin_editor_css_style_entry_http_response_handling() {
+		$test_cases = array(
+			array(
+				'test_condition_name'   => '200 応答（CSS 本文その1）の場合 => styles に1件追加される',
+				'body'                  => '.ltg-http-marker-1{color:red}',
+				'code'                  => 200,
+				'expected_count'        => 1,
+				'expected_css_contains' => '.ltg-http-marker-1{color:red}',
+			),
+			array(
+				'test_condition_name'   => '200 応答（CSS 本文その2、別内容）の場合 => styles に1件追加される',
+				'body'                  => '.ltg-http-marker-2{color:blue}',
+				'code'                  => 200,
+				'expected_count'        => 1,
+				'expected_css_contains' => '.ltg-http-marker-2{color:blue}',
+			),
+			array(
+				'test_condition_name'   => '404 応答（エラーページの HTML 本文）の場合 => 失敗として扱われ styles に何も追加されない',
+				'body'                  => '<html>404 Not Found</html>',
+				'code'                  => 404,
+				'expected_count'        => 0,
+				'expected_css_contains' => null,
+			),
+		);
+
+		foreach ( $test_cases as $index => $case ) {
+			$skin_key = 'http-response-skin-' . $index;
+
+			$tracker        = new stdClass();
+			$tracker->count = 0;
+			$http_filter    = function () use ( $case, $tracker ) {
+				++$tracker->count;
+				return array(
+					'headers'  => array(),
+					'body'     => $case['body'],
+					'response' => array(
+						'code'    => $case['code'],
+						'message' => '',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			};
+			add_filter( 'pre_http_request', $http_filter );
+			$this->http_filters[] = $http_filter;
+
+			$skins_filter = static function ( $skins ) use ( $skin_key ) {
+				$skins[ $skin_key ] = array(
+					'label'              => 'HTTP Response Skin (test)',
+					'gutenberg_css_path' => 'https://example.com/nowhere/http-response-test-' . $skin_key . '.css',
+				);
+				return $skins;
+			};
+			add_filter( 'lightning-design-skins', $skins_filter );
+			$this->skins_filters[] = $skins_filter;
+
+			update_option( 'lightning_design_skin', $skin_key );
+
+			$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+			$theme_entries   = $this->get_theme_style_entries( $editor_settings );
+
+			$this->assertCount( $case['expected_count'], $theme_entries, $case['test_condition_name'] );
+
+			if ( null !== $case['expected_css_contains'] ) {
+				$this->assertStringContainsString( $case['expected_css_contains'], $theme_entries[0]['css'], $case['test_condition_name'] );
+			}
+
+			$this->assertSame(
+				1,
+				$tracker->count,
+				$case['test_condition_name'] . '（HTTP リクエストは1回だけ発生する必要があります）'
+			);
+
+			// 次のケースへ影響しないよう、このケース専用のフィルターとオプションを都度取り除く
+			// （複数の pre_http_request フィルターが積み重なると、前のケースの $tracker まで
+			// 再カウントされてしまうため）.
+			remove_filter( 'pre_http_request', $http_filter );
+			remove_filter( 'lightning-design-skins', $skins_filter );
+			delete_option( 'lightning_design_skin' );
+		}
+	}
+
+	/**
+	 * get_skin_editor_css_style_entry() の HTTP フォールバック（get_remote_css_contents()）が、
+	 * 200 応答時に CSS を取得して styles へ追加すること、および transient キャッシュにより
+	 * 2回目の呼び出しでは実際の HTTP リクエストが発生しないことを検証する。
+	 *
+	 * 1回目・2回目の呼び出しという順序そのものが検証内容であり、条件の組み合わせ表には
+	 * ならないため単一シナリオのままにしている。
+	 */
+	public function test_http_fallback_succeeds_and_caches_via_transient() {
+		$marker  = '.ltg-http-marker-' . wp_generate_password( 8, false ) . '{color:red}';
+		$tracker = $this->mock_remote_response( $marker, 200 );
+
+		$filter = static function ( $skins ) {
+			$skins['http-ok-skin'] = array(
+				'label'              => 'HTTP OK Skin (test)',
+				'gutenberg_css_path' => 'https://example.com/nowhere/http-ok-test.css',
+			);
+			return $skins;
+		};
+		add_filter( 'lightning-design-skins', $filter );
+		$this->skins_filters[] = $filter;
+
+		update_option( 'lightning_design_skin', 'http-ok-skin' );
+
+		$editor_settings = Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+		$theme_entries   = $this->get_theme_style_entries( $editor_settings );
+
+		$this->assertCount( 1, $theme_entries, '200 応答時は styles に1件追加される必要があります。' );
+		$this->assertStringContainsString(
+			$marker,
+			$theme_entries[0]['css'],
+			'追加された内容は HTTP レスポンスのボディである必要があります。'
+		);
+		$this->assertSame( 1, $tracker->count, 'HTTP リクエストは1回だけ発生する必要があります。' );
+
+		// 2回目の呼び出し: transient が効いていれば、実際の HTTP リクエストは発生しない.
+		Lightning_Design_Manager::add_skin_css_to_block_editor_settings( array(), null );
+		$this->assertSame(
+			1,
+			$tracker->count,
+			'2回目の呼び出しでは transient キャッシュが効いて HTTP が発生してはいけません。'
+		);
+	}
+}

--- a/_g2/tests/test-lightning-design-manager-block-editor-styles.php
+++ b/_g2/tests/test-lightning-design-manager-block-editor-styles.php
@@ -192,6 +192,14 @@ class LightningDesignManagerBlockEditorStylesTest extends WP_UnitTestCase {
 	 * `$editor_settings['styles'] = array(...)` のような代入に書き換えられると、
 	 * 既存のエントリが丸ごと消えてしまう（エディターのスタイルが全滅する）。
 	 * それを検出するため、入力に既存エントリを含め、加工後も残っていることを検証する。
+	 *
+	 * bootstrap.min.css（1件目）が読めることの検証は、_g2 のパス解決の非対称
+	 * （get_template_directory_uri() は template_directory_uri フィルターで自動的に
+	 * /_g2 が付与されるが、get_template_directory() は付与されない）を実質的に固定する
+	 * 回帰テストを兼ねている。add_skin_css_to_block_editor_settings() の実装を
+	 * get_parent_theme_file_path() から get_template_directory() へ戻すと、bootstrap.min.css
+	 * が _g2 の無い誤ったパスで読めなくなり、theme エントリが1件（editor.css のみ）に
+	 * 減って本テストの assertCount(2, ...) が落ちる。
 	 */
 	public function test_add_skin_css_to_block_editor_settings_adds_bootstrap_and_skin_css_in_order() {
 		update_option( 'lightning_design_skin', 'origin2' );
@@ -215,7 +223,9 @@ class LightningDesignManagerBlockEditorStylesTest extends WP_UnitTestCase {
 		$this->assertCount(
 			2,
 			$theme_entries,
-			'bs4 系スキンでは bootstrap.min.css とスキンの editor.css の2件が styles に追加される必要があります。'
+			'bs4 系スキンでは bootstrap.min.css とスキンの editor.css の2件が styles に追加される必要があります。' .
+			'1件しか無い場合、_g2 では template_directory フィルターが無いため get_template_directory() では' .
+			'/_g2 が付与されずに bootstrap.min.css が読めていない可能性があります（get_parent_theme_file_path() を使う必要があります）。'
 		);
 
 		// 1件目（bootstrap.min.css）は baseURL を持たない（自テーマのサーバーパスを直接読むため）。
@@ -345,10 +355,10 @@ class LightningDesignManagerBlockEditorStylesTest extends WP_UnitTestCase {
 		$dir_with_space = WP_CONTENT_DIR . '/lightning test ' . wp_generate_password( 6, false );
 		mkdir( $dir_with_space ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
 		$this->temp_paths[] = $dir_with_space;
-		$file_with_space     = $dir_with_space . '/editor-gutenberg.css';
+		$file_with_space = $dir_with_space . '/editor-gutenberg.css';
 		file_put_contents( $file_with_space, '.ltg-space-marker{color:blue}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 		$this->temp_paths[] = $file_with_space;
-		$url_with_space      = content_url( '/' . rawurlencode( basename( $dir_with_space ) ) . '/editor-gutenberg.css' );
+		$url_with_space = content_url( '/' . rawurlencode( basename( $dir_with_space ) ) . '/editor-gutenberg.css' );
 
 		// ケース2: 日本語のファイル名（パーセントエンコードされた URL）.
 		$dir_ja = WP_CONTENT_DIR . '/lightning-test-' . wp_generate_password( 8, false );
@@ -357,7 +367,7 @@ class LightningDesignManagerBlockEditorStylesTest extends WP_UnitTestCase {
 		$file_ja = $dir_ja . '/エディタ.css';
 		file_put_contents( $file_ja, '.ltg-ja-marker{color:orange}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 		$this->temp_paths[] = $file_ja;
-		$url_ja  = content_url( '/' . basename( $dir_ja ) . '/' . rawurlencode( 'エディタ.css' ) );
+		$url_ja = content_url( '/' . basename( $dir_ja ) . '/' . rawurlencode( 'エディタ.css' ) );
 
 		// ケース3: '../' によるパストラバーサル（非エンコード）。WP_CONTENT_DIR から見て
 		// ABSPATH . 'wp-load.php'（標準構成で確実に存在する）を狙う。

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,7 @@ vk-develop@vektor-inc.co.jp
 
 [ Spec Change ] Raise the minimum required WordPress version from 6.5 to 6.6, because the Lightning design setting panel in the block editor sidebar does not appear on WordPress 6.5
 [ G2/G3 ][ Design Bug Fix ] Restore the spacing between the layout, page header/breadcrumb, and padding groups in the Lightning design setting panel (block editor sidebar) that was lost on WordPress 7.0
+[ G2 ][ Design Bug Fix ] Fix the block editor's skin CSS leaking into the admin screen as a whole and overriding the base font size, causing the "Collapse menu" button label at the bottom of the admin sidebar to wrap
 
 v15.40.0
 [ G2 ][ Spec Change ] Widen the horizontal padding of buttons and input fields to match Lightning Pro, on sites using a bs4 design skin such as Origin II


### PR DESCRIPTION
## 概要

**ブロックエディター（投稿の編集画面）用のスキン CSS が、編集画面だけでなく管理画面全体にも適用されていました。** その結果、管理画面の基準文字サイズが書き換わり、**左サイドバー最下部の「メニューを閉じる」ボタンの文字が折り返されて表示が崩れます。**

Lightning Pro で先に直した不具合（vektor-inc/lightning-pro#416 / PR vektor-inc/lightning-pro#417）を、無料版 Lightning の `_g2` へ移植したものです。

関連タスク: vektor-inc/multi-repo-tasks#43（Lightning 系の変更をまとめたタスク）のチェックリスト 1 番目

@coderabbitai ignore

## 原因

`_g2/inc/class-design-manager.php` の `load_skin_gutenberg_css()` が、`enqueue_block_assets`（ブロック用のアセットを読み込むフック）で `wp_enqueue_style()` を使っていました。**このフックは編集画面だけでなく管理画面全体で動くため、CSS が `<link>` として管理画面の文書に直接出ます。**

スキンの `editor.css` には、要素を限定しない裸の `body` / `html` 規則があります。

```css
/* _g2/design-skin/origin2/css/editor.css */
body,html{font-size:14px}
body{font-family:"メイリオ",Meiryo,"Hiragino Kaku Gothic Pro",…}
@media (992px < width){body,html{font-size:16px}}
```

これが管理画面の `<html>` / `<body>` にそのまま当たり、**WordPress 管理画面の基準文字サイズとフォントを丸ごと上書き**していました。

`_g2/design-skin/origin/css/editor.css`（Origin スキン）にも `body` / `html` の出現が 37 箇所あります。

**`_g3` は影響を受けません。** `_g3/design-skin/origin3/css/editor.css` の裸の `body` / `html` 規則は 0 件で、`.editor-styles-wrapper body` のようにスコープ済みのセレクタで書かれています。**この修正は「G3 に合わせて G2 の漏れを塞ぐ」形**であり、新しい食い違いを生むのではなく既存の食い違いを無くす方向です。

## 修正方法

`enqueue_block_assets` での `wp_enqueue_style()` をやめ、**`block_editor_settings_all` フィルターで CSS の中身を `$editor_settings['styles']` へ直接渡す**方式に変えました。

エディタはこの配列を受け取ると、**自分の iframe の中だけ**（または `.editor-styles-wrapper` へセレクタを書き換えて）適用します。管理画面の文書には `<link>` が出ないため、構造的に漏れません。

### `add_editor_style()` を使わない理由

`_g3/inc/class-lightning-design-manager.php` に、この判断の元になる注意書きが残っています。

| `add_editor_style()` の限界 | 今回の方式での扱い |
| --- | --- |
| テーマ外（スキンプラグインなど）の CSS 読み込みが効かない | **解決済み。** CSS ファイルを PHP 側で直接読み、中身を `styles` へ渡すため、置き場所を問いません |
| `.editor-styles-wrapper` を自動付与するので詳細度が上がる | **発生しません。** エディタが iframe 化されている限り、コアはセレクタを書き換えず iframe 内へそのまま流します |

## `_g2` 向けに変えた点

移植元は別プロダクトなので、そのままコピーはしていません。

### 1.【最重要】bootstrap.min.css のサーバーパスの組み立て

`get_template_directory()` ではなく **`get_parent_theme_file_path()`** を使っています。

`_g2` には、**フィルターの非対称**があります。

```php
// inc/class-ltg-template-redirect.php
30:  add_filter( 'template_directory_uri', ... );         // 有効 → /_g2 が付く
33:  add_filter( 'parent_theme_file_path', ..., 10, 2 );  // 有効 → /_g2 が付く
35:  // add_filter( 'template_directory', ... );          // コメントアウト → 付かない
```

`get_template_directory() . '/library/bootstrap-4/…'` は `themes/lightning/library/bootstrap-4/…` という**存在しないパス**を指します。すると `get_local_css_contents()` が `null` を返し、**bootstrap.min.css が黙って読まれなくなります。**

この退行はテストで守っています。`test_add_skin_css_to_block_editor_settings_adds_bootstrap_and_skin_css_in_order()` が `assertCount(2)` で落ち、失敗メッセージにこの事情を明記してあります。

### 2. `get_skins()` に `editor_css_sv_path` を追加

移植元にはあったが `_g2` の既存 `get_skins()` に無かったキーです（Origin・Origin II 双方）。これにより同梱スキンは URL の逆算も HTTP 取得も一切通らず、サーバーパスから直接読みます。

### 3. `is_customize_preview()` の早期リターンを削除

旧実装は `<link>` を文書へ直接出すため、カスタマイザーで発火すると管理画面本体に漏れました。**新方式は `$editor_settings['styles']` への追記のみなので、構造的に漏れません。**

カスタマイザーの管理ペインでブロックウィジェット編集を開くと `block_editor_settings_all` は発火しますが、コアの `EditorStyles` がセレクタを iframe 内 body または `.editor-styles-wrapper` へ書き換えてから描画するため、`customize.php` 本体の `<body>` には到達しません。

### 4. 外部スキンプラグイン用の HTTP 取得は移植しています

`_g2` にも `get_skins_info()`（variety / charm / jpnstyle / fort / pale の bs3・bs4 系 12 キー）と `apply_filters( 'lightning-design-skins', $skins )` が実在します。`*_sv_path` を持たない旧スキンプラグインが `gutenberg_css_path` に URL を返す構成があり得るため、`get_remote_css_contents()` は必要と判断しました。

## `widgets.php` だけ別扱いにしている理由

**旧実装のバグのおかげで、たまたま正しく見えていた画面があります。**

`widgets.php`（外観 > ウィジェット）は iframe 化されていません。漏れていた `body,html{font-size:14px}` が実の `<html>` にも当たっていたため、`.h2, .mainSection-title, h2 { font-size: 1.75rem }` のような **rem 指定の見出しがフロントと同じ大きさに見えていました。**

漏れを塞ぐと、コアが `html` セレクタを `.editor-styles-wrapper` へ書き換えるため rem の基準が変わり、**見出しだけ妙に大きくなります。** そこで `add_root_font_size_for_block_editor()` で、`widgets.php` に限って実の `<html>` へ同じブレークポイント・同じ比率を与えて帳尻を合わせています。

```
992px 以下: 87.5%   （= 14px 相当）
992px 超  : 100%    （= 16px 相当）
```

**単位に `px` ではなく `%` を選んでいます。** ブラウザの既定文字サイズを大きくしている利用者の設定を握りつぶさず、相対的なスケールを保ったまま同じ比率を再現するためです。

## 管理画面への影響

`body{font-family:"メイリオ",…}` を含む漏れが根こそぎ止まります。投稿一覧・設定画面など**管理画面全体で、ブラウザの既定フォント・文字サイズ設定が無条件に上書きされていた状態が解消**されます。ブラウザの既定文字サイズを大きくしている利用者にとっては素直に改善です。

## テスト

`_g2/tests/test-lightning-design-manager-block-editor-styles.php` を新規追加しました（9 メソッド）。

| テスト | 何を守るか |
| --- | --- |
| `..._returns_unchanged_outside_admin` | 管理画面の外では設定を書き換えない |
| `..._adds_bootstrap_and_skin_css_in_order` | bs4 系で 2 件が正しい順で追加される（**上記 1 のパス解決の回帰テストを兼ねる**） |
| `..._bs4_branching` | `bootstrap` キーによる分岐 |
| `..._gutenberg_css_path_url_resolution` | URL からサーバーパスへの逆算 |
| `test_enqueue_block_assets_does_not_enqueue_legacy_editor_styles` | **旧実装の復活を検出**（`lightning-gutenberg-editor` / `lightning-bootstrap-editor` が再登場しない） |
| `..._only_applies_on_widgets_screen` | `post.php` / `site-editor.php` では出力せず `widgets.php` でのみ出力 |
| `test_sv_path_takes_priority_over_url_resolution_and_http` | サーバーパス優先 |
| `..._http_response_handling` | HTTP 応答の扱い |
| `test_http_fallback_succeeds_and_caches_via_transient` | HTTP フォールバックと transient キャッシュ |

実行結果: **OK (36 tests, 213 assertions)** — `_g2` の全体スイート、全通過。

パストラバーサルの検証は 6 ケース（スペース入りディレクトリ / 日本語ファイル名 / 非エンコードの `../` / `%2e%2e%2f` / 境界 URL / `%00`）で固定しています。

## 確認手順

### 前提条件

- **G2** で確認します（`lightning_theme_generation` オプションで切り替え）
- **デザインスキンは Origin II（origin2）** を選びます。裸の `body` / `html` 規則を持つのはこちらです
- **ブラウザキャッシュを無効化してください**

### 1. 不具合が直っていること（本丸）

1. 管理画面 > 投稿 > 新規追加 で投稿編集画面を開く
2. 左サイドバー最下部の「メニューを閉じる」ボタンを見る
   - → ✓ **修正前は文字が折り返されて表示が崩れる**
   - → ✓ **修正後は折り返さない**
3. 検証ツールで `<html>` の `font-size` を見る
   - → ✓ 修正前は `14px`（スキン由来）、修正後は WordPress 標準の値

### 2. 編集キャンバスの中が変わっていないこと

1. 投稿本文に段落・見出し（h2 / h3）・ボタン・テーブルを置く
   - → ✓ 文字サイズ・フォント・余白が修正前と変わっていない
   - → ✓ フロント（公開ページ）の見た目とも一致している

### 3. 非 iframe の画面

1. **外観 > ウィジェット**（`widgets.php`）
   - → ✓ 見出しの大きさが修正前と変わっていない
   - → ✓ ブラウザ幅を 992px の前後で変えると、基準文字サイズが `87.5%` ↔ `100%` で切り替わる
2. **外観 > カスタマイズ > ウィジェット**
   - → ✓ カスタマイザー本体の文字サイズが崩れていない

### 4. 管理画面の他の画面

1. 投稿一覧、設定 > 一般、プラグイン一覧
   - → ✓ 表示が崩れていない
   - → ✓ 文字サイズ・フォントが WordPress 標準に戻っている（**これは改善なので、変わっていて正しい**）

### 5. フロント表示

1. トップページ・投稿詳細
   - → ✓ 変わっていない（管理画面側だけの修正のため）

## 実機確認の結果（麗美）

**`master` で不具合が再現し、本ブランチで直っていることを実機で確認済みです。** G2 ＋ デザインスキン Origin II、ブラウザキャッシュ無効化のうえで測定しています。

### 「メニューを閉じる」ボタン

| Before（`master`） | After（本ブランチ） |
| --- | --- |
| ![Before](https://github.com/vektor-inc/review-assets/blob/main/lightning/pr-1456/before-collapse-menu-button-zoom.png?raw=true) | ![After](https://github.com/vektor-inc/review-assets/blob/main/lightning/pr-1456/after-collapse-menu-button-zoom.png?raw=true) |
| 「メニューを閉じ／る」と 2 行に折り返す | 1 行に収まる |

**画面上で効いていたのは `font-size` ではなく `font-family` の漏れでした。**

| | `master` | 本ブランチ |
| --- | --- | --- |
| `document.body`（管理画面）の `font-family` | `メイリオ, Meiryo, …`（**スキンからの漏れ**） | `-apple-system, system-ui, …`（WordPress 標準） |
| `document.body`（管理画面）の `font-size` | — | `13px`（WordPress 標準） |

Meiryo は標準の管理画面フォントより横幅を食うため、ボタンのラベルが収まらず折り返していました。

### 編集キャンバスの中

段落・H2・H3・テーブル・ボタンを配置して比較。**サイズ・行間は完全に一致**しました（`p` = 16px、`h2` / `h3` = 28px = 1.75rem、`button` / `table` = 16px、`line-height` も同一）。

| Before | After |
| --- | --- |
| ![Before](https://github.com/vektor-inc/review-assets/blob/main/lightning/pr-1456/before-editor-content.jpg?raw=true) | ![After](https://github.com/vektor-inc/review-assets/blob/main/lightning/pr-1456/after-editor-content.jpg?raw=true) |

**1 点だけ、副次的に改善している箇所があります。** `.editor-styles-wrapper` の `font-family` は、`master` では別 CSS（`:where(.editor-styles-wrapper){font-family:var(--vk-font-family)}`）が偶然 Meiryo 指定を上書きして汎用 sans-serif になっていました。本ブランチでは Meiryo が正しく適用されます。フロント（`body` = Meiryo / 16px / `h2` = 28px）と実測で突き合わせたところ、**本ブランチのほうがフロントとの一致度が高い**という結果でした。退行ではなく改善です。

### `widgets.php` の帳尻合わせ

**`master` と本ブランチで完全に一致しました。**

| ブラウザ幅 | `master` の `<html>` | 本ブランチの `<html>` | H2 実測 |
| --- | --- | --- | --- |
| 992px 超 | 16px | 16px | 28px（一致） |
| 992px 以下 | 14px（**旧バグの偶然の帳尻**） | 14px（`html{font-size:87.5%}` による**意図した帳尻**） | 24.5px（一致） |

![widgets.php](https://github.com/vektor-inc/review-assets/blob/main/lightning/pr-1456/after-widgets-wide.jpg?raw=true)

### カスタマイザーのブロックウィジェット編集

外観 > カスタマイズ > ウィジェットでブロック編集パネルを表示。カスタマイザー本体の `<html>` = 16px、`body` = 13px、フォントは WordPress 標準で崩れなし。

### 管理画面の他の画面・フロント

投稿一覧・設定 > 一般・プラグイン一覧を確認し、`master` と差分なし（`html` = 16px、`body` = 13px、WordPress 標準フォント）。

**実測で分かったこと**: `enqueue_block_assets` フックはこれらの画面では発火しないため、**旧実装の不具合はもともとこれらの画面には影響していませんでした。** 影響していたのはブロックエディターを開く画面（投稿編集画面・`widgets.php` など）です。

フロント（トップページ・投稿詳細）も `body` = Meiryo / 16px / `h2` = 28px のままで、`master` 相当の見た目を維持しています。

## レビュー状況

| 担当 | 結果 |
| --- | --- |
| 安藤（リードエンジニア） | `セキュリティレビュー結果: PASS` / `コード品質レビュー結果: PASS（マージ可）` |
| 植草（UX デザイナー） | `UXレビュー結果: PASS` |
| 麗美（UI テスト） | `テスト結果: PASS` |
| Claude Code の code-review | 実施・**指摘なし** |

### 安藤（静的解析）

**移植元と `diff -u` で全行突き合わせ、`resolve_content_url_to_path()` / `get_local_css_contents()` / `get_remote_css_contents()` / `get_skin_editor_css_style_entry()` の 4 メソッドに 1 行の差分もないことを確認しています。** 「移植したつもりで防御が 1 行落ちる」のを防ぐためです。

**パストラバーサル対策**の処理順が正しく維持されていることを確認済みです。

1. `content_url()` 前方一致
2. クエリ・フラグメント除去（`strtok()` を避け `preg_replace()`）
3. `rawurldecode()` — **デコードを先に行い**、その後で正規化・封じ込め判定（`%2e%2e%2f` を復元してから弾く順序）
4. NUL バイト除去（`realpath()` 到達前）
5. `realpath()` で正規化 → `WP_CONTENT_DIR` 配下チェック（`$real_content_dir . '/'` の前方一致で `wp-content-evil` のような境界すり抜けも封じる）
6. `is_file()`

**SSRF**: `wp_safe_remote_get()`（`reject_unsafe_urls` 有効）で、プライベート IP・非 HTTP スキーム・リダイレクト先まで検証されます。`timeout => 3`。URL の出所は `lightning-design-skins` フィルター、つまり既に PHP 実行権を持つプラグインで、未認証・低権限ユーザーが注入できる経路はありません。

**出力側**: CSS は `$editor_settings['styles']` に入り、コアが `wp_json_encode()` を通して JS へ渡し、React が `<style>` のテキストノードとして描画します。HTML パースが起きないため `</style>` 混入による breakout は成立しません。

### 植草（UX）

`87.5%` / `100%` を `px` ではなく `%` にした判断が、ブラウザ既定文字サイズの利用者設定を尊重する点でアクセシビリティ的に好ましいと評価。`widgets.php` の狭幅時にチェックボックス・ラジオボタンが約 2px 縮む副作用も、コードコメントにトレードオフとして明記済みです。

## この PR では対応しない申し送り

1. **`add_root_font_size_for_block_editor()` が `$pagenow === 'widgets.php'` の一致に依存**しています。将来 WordPress がウィジェット編集画面を別の `pagenow` で提供するようになると、同じ非 iframe 問題が再発する余地があります。現状の WordPress では実害がないため対応していません
2. **`get_local_css_contents( $sv_path )` は `$sv_path` に封じ込めチェックを掛けません**（URL 経由とは非対称）。`*_sv_path` の出所は既に PHP 実行権を持つプラグインのため権限境界としては問題なく、移植元と同一で退行でもありません
3. **`get_remote_css_contents()` に取得ボディのサイズ上限・Content-Type 検査がありません。** URL の出所がプラグイン、TTL 最大 1 日、autoload なしのため実害は限定的です。移植元と同一
4. **bootstrap のサーバーパスが `lightning_is_g3()` に間接依存**します（`parent_theme_file_path` フィルター内で呼ばれるため）。`dirname( __DIR__ )` なら構造的に免疫がありますが、このファイルは `css_sv_path` / `php_path` も一貫して `get_parent_theme_file_path()` を使っており、揃えている現状のほうが読み手に親切と判断しました

## 関連

- vektor-inc/lightning-pro#416（Lightning Pro 側の元の不具合報告）
- vektor-inc/lightning-pro#417（移植元。マージ済み）
- vektor-inc/multi-repo-tasks#43（Lightning 系の変更をまとめたタスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW4v8GiDdxZUGWuNViqFny
