### PR TITLE
[ 開発環境 ] Lightning Pro と書き方を揃えるため、sass のバージョン指定をキャレット範囲から厳密固定へ変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"postcss": "^8.5.28",
 				"rimraf": "^5.0.7",
 				"run-sequence": "^2.2.1",
-				"sass": "^1.104.0",
+				"sass": "1.104.0",
 				"through2": "^4.0.2",
 				"vinyl-sourcemaps-apply": "^0.2.1",
 				"webpack": "^5.110.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"postcss": "^8.5.28",
 		"rimraf": "^5.0.7",
 		"run-sequence": "^2.2.1",
-		"sass": "^1.104.0",
+		"sass": "1.104.0",
 		"through2": "^4.0.2",
 		"vinyl-sourcemaps-apply": "^0.2.1",
 		"webpack": "^5.110.3",


### PR DESCRIPTION
## 概要

`package.json` の `sass` を、キャレット範囲から**厳密固定**へ変えます。

```diff
-  "sass": "^1.104.0",
+  "sass": "1.104.0",
```

**vektor-inc/lightning-pro 側と書き方を揃えるため**です（Pro は元から厳密固定）。ユーザー本人の指示によるものです。

@coderabbitai ignore

## 変更内容

2 ファイル 2 行だけです。

| ファイル | 変更 |
| --- | --- |
| `package.json:61` | `"^1.104.0"` → `"1.104.0"` |
| `package-lock.json:38`（`packages[""].devDependencies` のミラー） | 同上 |

**依存の解決先は 1 バイトも動いていません。** `node_modules/sass` エントリの `version` / `resolved` / `integrity` は不変で、lock の差分はルートマニフェストの 1 行のみです。

## `package-lock.json` を手で書き換えた理由

`npm install` で lock を更新したところ、sass の 1 行に加えて **`@parcel/watcher-linux-*` 6 パッケージから `"libc": ["glibc"]` / `["musl"]` が消える 18 行の差分**が出ました。

実装担当が `package.json` を元の `^1.104.0` へ戻した状態でも `npm install` を実行し、**まったく同じ 18 行が再現すること**を確認しています。つまり sass の指定変更とは無関係で、手元の npm（10.8.2 / node 24.16.0）が lock を生成した npm より新しいことによる副作用です。

そこで **`package-lock.json` を `master` から復元したうえで、sass の 1 行だけを手で書き換えました。** 理由は 2 つです。

1. `package.json` だけ変えて lock を元のままにすると、**`npm ci` が out of sync で落ちます**
2. `libc` フィールドは glibc / musl のどちらの環境向けバイナリを選ぶかの判定に使われるため、**巻き込むと Linux の CI 環境で optional 依存の選択が変わりえます**

`libc` フィールドは `master` と同じ 6 件のまま温存されています。

## 検証

- **`node_modules` を丸ごと削除してから `npm ci` を実行し、out of sync エラーなしで正常終了**（`added 2167 packages`）
- `npm run build:sass` 実行後、**CSS ファイルの差分ゼロ**
- インストールされた sass は `1.104.0`（`1.104.0 compiled with dart2js 3.13.3`）

レビュー時に安藤が独立に検算しています。

- `package-lock.json` は `lockfileVersion: 3` のため、**追随が必要な旧 `dependencies` セクションは存在しません。** 触るべきミラーは `packages[""].devDependencies` の 1 箇所だけで、手編集の形として正しい
- ブランチの 2 ファイルだけを取り出して `npm ci --dry-run` → out of sync エラーなし。**ミューテーション検証**として `package.json` だけ `1.103.0` に書き換えて再実行すると `Invalid: lock file's sass@1.104.0 does not satisfy sass@1.103.0` で正しく落ちることも確認（検査自体が効いていることの裏取り）
- `sass` を要求しているのは `@wordpress/scripts`（deps `^1.54.0`）と `sass-loader`（peer `^1.3.0`）の 2 つのみで、`1.104.0` は両方を満たす。lock 内に入れ子の `node_modules/*/node_modules/sass` も無く、**衝突なし**
- `overrides` / `resolutions` / `.npmrc` はいずれも無し

## ⚠️ この変更で再発は止まりません

**期待値を明示しておきます。厳密固定にしても、Dependabot は sass を上げます。**

npm エコシステムの Dependabot は**要求そのものを書き換える**方式です。1.105 が出れば `"1.104.0"` → `"1.105.0"` と `package.json` ごと書き換える PR を出し、`sass` は `.github/dependabot.yml` の `npm-development` グループ（`dependency-type: development` / `update-types: [minor, patch]`）に入るため、`dependabot-auto-merge` が CI 通過後にマージします。

逆にキャレットのままなら 1.105 は `^1.104.0` を満たすので lock だけの更新になります。**どちらの経路でも lock の sass は上がり、コミット済み CSS との食い違いは同じように起きます。**

この PR で得られるのは次の 2 点だけです。

1. **Lightning Pro と書き方が揃う**（当初の目的）
2. **Dependabot が上げるとき `package.json` の差分に現れる。** キャレットのままだと lock だけの差分に埋もれるため、レビューで気づきにくくなります

**当初この PR を「再発防止になる」と説明していましたが、それは誤りでした。** 訂正します。

## 再発を実際に止めるには（この PR では対応しません）

vektor-inc/lightning#1452 の状態は、現状 CI では検出できません。`.github/workflows/build_check.yml` は `npm ci` ではなく **`npm install`** を使っており、しかも `npm run build` の結果を**コミット済み CSS と突き合わせていません**。

塞ぐなら次のどちらかになります。**ユーザーの判断により、この PR では対応していません。**

1. `.github/dependabot.yml` で `sass` を `ignore` してグループから外す
2. `build_check.yml` を `npm ci` にしたうえで、ビルド後に `git diff --exit-code` で CSS 差分を落とす

## 補足: Lightning Pro に `dependabot.yml` はありません

揃え先の vektor-inc/lightning-pro には `.github/dependabot.yml` が**存在しません**。Pro の `"1.77.8"` が長く据え置かれてきたのは厳密固定のおかげではなく、単に Dependabot が動いていないためです。**書き方を揃えても、同じ挙動になるわけではありません。**

## 補足: このリポジトリで厳密固定は sass だけになります

`package.json` の依存 30 件はすべてキャレット指定で、**厳密固定はこれまで 0 件**でした。この PR で `sass` が唯一の例外になります。

**意図的な逸脱です。** Lightning Pro 側と書き方を揃えるためで、理由はこの本文に記録しています。他の依存へ広げる意図はありません。

## changelog に記載していない理由

`sass` は `devDependencies` にあり、配布物（テーマの zip）には含まれません。**ビルド後の CSS も 1 バイトも変わらないことを確認済み**のため、`rules/changelog.md`「記載しない — 開発用のパッケージ」に該当します。

## 確認手順

1. このブランチをチェックアウトする
2. `rm -rf node_modules && npm ci`
   - → ✓ **out of sync エラーが出ずに正常終了する**（ここがこの PR の要点です）
3. `npx sass --version`
   - → ✓ `1.104.0` と表示される
4. `npm run build:sass` を実行し、`git status` を見る
   - → ✓ **CSS ファイルの差分が出ない**

## レビュー状況

| 担当 | 結果 |
| --- | --- |
| 安藤（リードエンジニア） | `セキュリティレビュー結果: PASS` / `コード品質レビュー結果: PASS（マージ可）` |
| 植草（UX デザイナー） | ⏭️ スキップ — 変更は `package.json` / `package-lock.json` の 2 行のみ。`rules/ux-review.md` 総則の (a) UI 系ファイルの変更・(b) 利用者向け文言の追加変更のいずれにも該当しません |

## 関連

- vektor-inc/lightning#1452（保存済み CSS が現行のビルド環境で再現しない件）
- vektor-inc/lightning#1454（その再生成。sass 1.104.0 で焼き直し済み）
- vektor-inc/lightning-pro の `change/sass-1-104-0`（Pro 側を 1.104.0 へ揃える対応。並行して進めています）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW4v8GiDdxZUGWuNViqFny
